### PR TITLE
feat: Brief v0.2 — sync engine + doctor + assign + decision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fureworks/brief",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Team working memory for AI agents and humans.",
   "main": "index.js",
   "directories": {

--- a/src/cli/assign.ts
+++ b/src/cli/assign.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { getBriefDir, DIRS } from "../store/paths.js";
+import { makeFrontmatter } from "../store/frontmatter.js";
+import { computeHash, writeHash } from "../store/hash.js";
+
+export async function assignCommand(person: string, item: string): Promise<void> {
+  const briefDir = getBriefDir();
+
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  const peopleDir = join(briefDir, DIRS.people);
+  mkdirSync(peopleDir, { recursive: true });
+
+  const personFile = join(peopleDir, `${person.toLowerCase()}.md`);
+  let content: string;
+
+  if (existsSync(personFile)) {
+    content = readFileSync(personFile, "utf-8");
+    // Update the updated timestamp
+    content = content.replace(/updated: .+/, `updated: ${new Date().toISOString()}`);
+    // Append to assigned section
+    if (content.includes("## Assigned")) {
+      content = content.replace("## Assigned", `## Assigned\n- ${item} (assigned ${new Date().toISOString().split("T")[0]})`);
+    } else {
+      content += `\n## Assigned\n- ${item} (assigned ${new Date().toISOString().split("T")[0]})\n`;
+    }
+  } else {
+    const fm = makeFrontmatter();
+    content = fm + `# ${person.charAt(0).toUpperCase() + person.slice(1)}\n\n## Current Focus\n- ${item}\n\n## Assigned\n- ${item} (assigned ${new Date().toISOString().split("T")[0]})\n`;
+  }
+
+  writeFileSync(personFile, content);
+  writeHash(computeHash());
+
+  console.log(chalk.green(`  ✓ Assigned ${item} to ${person}\n`));
+}

--- a/src/cli/decision.ts
+++ b/src/cli/decision.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { getBriefDir, FILES } from "../store/paths.js";
+import { computeHash, writeHash } from "../store/hash.js";
+
+export async function decisionCommand(description: string): Promise<void> {
+  const briefDir = getBriefDir();
+
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  const decFile = join(briefDir, FILES.decisions);
+  let content = existsSync(decFile) ? readFileSync(decFile, "utf-8") : "";
+
+  const today = new Date().toISOString().split("T")[0];
+  const entry = `- **${description}**\n  Source: manual (${new Date().toISOString()})`;
+
+  // Update timestamp
+  content = content.replace(/updated: .+/, `updated: ${new Date().toISOString()}`);
+
+  // Find today's section or create it
+  if (content.includes(`## ${today}`)) {
+    content = content.replace(`## ${today}`, `## ${today}\n${entry}`);
+  } else {
+    // Add after the first heading
+    const headingEnd = content.indexOf("\n# ");
+    if (headingEnd > 0) {
+      const insertPoint = content.indexOf("\n", headingEnd + 1);
+      content = content.slice(0, insertPoint + 1) + `\n## ${today}\n${entry}\n` + content.slice(insertPoint + 1);
+    } else {
+      content += `\n## ${today}\n${entry}\n`;
+    }
+  }
+
+  writeFileSync(decFile, content);
+  writeHash(computeHash());
+
+  console.log(chalk.green(`  ✓ Decision logged: ${description}\n`));
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { getBriefDir, FILES } from "../store/paths.js";
+import { loadConfig } from "../store/config.js";
+
+export async function doctorCommand(): Promise<void> {
+  const briefDir = getBriefDir();
+
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  const config = loadConfig();
+
+  console.log("");
+  console.log(chalk.bold("  Brief Doctor"));
+  console.log(chalk.dim("  ────────────"));
+
+  // Check config
+  const hasConfig = config.sources.length > 0;
+  console.log(`  ${hasConfig ? chalk.green("✅") : chalk.yellow("⚠️")} Config: ${hasConfig ? `${config.sources.length} sources configured` : "no sources in brief.toml"}`);
+
+  // Check source health
+  const sourcesFile = join(briefDir, FILES.sources);
+  if (existsSync(sourcesFile)) {
+    const sourcesContent = readFileSync(sourcesFile, "utf-8");
+    const lines = sourcesContent.split("\n").filter(Boolean);
+
+    console.log("");
+    console.log(chalk.bold("  Sources"));
+    console.log(chalk.dim("  ───────"));
+
+    for (const line of lines) {
+      const nameMatch = line.match(/^(\w+):/);
+      const statusMatch = line.match(/status=(\w+)/);
+      const itemsMatch = line.match(/items=(\d+)/);
+      const durationMatch = line.match(/duration=(\d+)ms/);
+      const errorMatch = line.match(/error="([^"]*)"/);
+      const lastMatch = line.match(/last_success=([^\s]+)/);
+
+      const name = nameMatch?.[1] || "unknown";
+      const status = statusMatch?.[1] || "unknown";
+      const items = itemsMatch?.[1] || "0";
+      const duration = durationMatch?.[1] || "?";
+      const lastSuccess = lastMatch?.[1] || "";
+
+      let ageStr = "";
+      if (lastSuccess) {
+        const age = Date.now() - new Date(lastSuccess).getTime();
+        ageStr = age < 3600000 ? `${Math.round(age / 60000)}m ago` :
+                 age < 86400000 ? `${Math.round(age / 3600000)}h ago` :
+                 `${Math.round(age / 86400000)}d ago`;
+      }
+
+      const indicator = status === "healthy" ? chalk.green("✅") :
+                       status === "error" ? chalk.red("❌") : chalk.yellow("⚠️");
+
+      console.log(`  ${indicator} ${name.padEnd(15)} ${items} items  ${duration}ms  ${chalk.dim(ageStr)}`);
+      if (errorMatch) {
+        console.log(chalk.red(`     Error: ${errorMatch[1]}`));
+      }
+    }
+  } else {
+    console.log(chalk.dim("\n  No sync history. Run 'brief sync' to populate."));
+  }
+
+  // Check notifications
+  console.log("");
+  console.log(chalk.bold("  Notifications"));
+  console.log(chalk.dim("  ─────────────"));
+  console.log(`  ${config.notify.enabled ? chalk.green("✅ Telegram enabled") : chalk.dim("Disabled (set notify.enabled=true in brief.toml)")}`);
+
+  console.log("");
+}

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -1,0 +1,244 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import chalk from "chalk";
+import { getBriefDir, FILES, DIRS } from "../store/paths.js";
+import { loadConfig, BriefConfig } from "../store/config.js";
+import { makeFrontmatter } from "../store/frontmatter.js";
+import { computeHash, writeHash } from "../store/hash.js";
+
+const execAsync = promisify(exec);
+
+interface SourceResult {
+  name: string;
+  target: string;
+  items: unknown[];
+  error?: string;
+  duration: number;
+}
+
+async function runSource(source: BriefConfig["sources"][0]): Promise<SourceResult> {
+  const start = Date.now();
+
+  if (source.type === "file") {
+    try {
+      const content = readFileSync(source.path || "", "utf-8");
+      return { name: source.name, target: source.target, items: [{ raw: content }], duration: Date.now() - start };
+    } catch (e: any) {
+      return { name: source.name, target: source.target, items: [], error: e.message, duration: Date.now() - start };
+    }
+  }
+
+  if (source.type === "command" && source.command) {
+    try {
+      const { stdout } = await execAsync(source.command, {
+        timeout: (source.timeout || 15) * 1000,
+        encoding: "utf-8",
+      });
+      const parsed = JSON.parse(stdout);
+      const items = Array.isArray(parsed) ? parsed : parsed.now ? [...(parsed.now || []), ...(parsed.today || [])] : [parsed];
+      return { name: source.name, target: source.target, items, duration: Date.now() - start };
+    } catch (e: any) {
+      return { name: source.name, target: source.target, items: [], error: e.message?.slice(0, 100), duration: Date.now() - start };
+    }
+  }
+
+  return { name: source.name, target: source.target, items: [], error: "Unknown source type", duration: 0 };
+}
+
+function renderPriorities(results: SourceResult[], config: BriefConfig): string {
+  const fm = makeFrontmatter({ sources: results.map((r) => r.name) });
+  const lines: string[] = [fm, "# Priorities", ""];
+
+  // Read overrides
+  const briefDir = getBriefDir();
+  const overridesPath = join(briefDir, FILES.overrides);
+  let overrideContent = "";
+  if (existsSync(overridesPath)) {
+    overrideContent = readFileSync(overridesPath, "utf-8");
+  }
+
+  // Check for urgent in overrides
+  const urgentMatch = overrideContent.match(/## Add\n([\s\S]*?)(?=\n##|$)/);
+  if (urgentMatch) {
+    const addItems = urgentMatch[1].trim();
+    if (addItems && !addItems.startsWith("#")) {
+      lines.push("## 🔴 OVERRIDE", addItems, "");
+    }
+  }
+
+  // Collect items from all priority-targeted sources, sorted by source priority
+  const priorityResults = results
+    .filter((r) => r.target === "priorities" && r.items.length > 0)
+    .sort((a, b) => {
+      const aPri = config.sources.find((s) => s.name === a.name)?.priority || 0;
+      const bPri = config.sources.find((s) => s.name === b.name)?.priority || 0;
+      return bPri - aPri;
+    });
+
+  const nowItems: string[] = [];
+  const todayItems: string[] = [];
+  let ignoredCount = 0;
+
+  for (const result of priorityResults) {
+    for (const item of result.items) {
+      const i = item as Record<string, unknown>;
+      if (i.priority === "now" || i.priority === "NOW") {
+        const label = i.label || i.title || i.id || "Unknown";
+        const detail = i.detail || i.description || "";
+        const reason = i.reason || "";
+        nowItems.push(`- ${label}\n  ${detail}${reason ? `\n  Why: ${reason}` : ""}\n  Source: ${result.name}`);
+      } else if (i.priority === "today" || i.priority === "TODAY") {
+        const label = i.label || i.title || i.id || "Unknown";
+        const detail = i.detail || i.description || "";
+        const reason = i.reason || "";
+        todayItems.push(`- ${label}\n  ${detail}${reason ? `\n  Why: ${reason}` : ""}\n  Source: ${result.name}`);
+      } else {
+        ignoredCount++;
+      }
+    }
+  }
+
+  if (nowItems.length > 0) {
+    lines.push("## NOW", ...nowItems, "");
+  }
+  if (todayItems.length > 0) {
+    lines.push("## TODAY", ...todayItems, "");
+  }
+  if (ignoredCount > 0) {
+    lines.push(`## IGNORED (${ignoredCount} items)`, "");
+  }
+
+  // Check for remove overrides
+  const removeMatch = overrideContent.match(/## Remove\n([\s\S]*?)(?=\n##|$)/);
+  if (removeMatch) {
+    const removeLines = removeMatch[1].trim().split("\n").filter((l) => l.startsWith("- "));
+    if (removeLines.length > 0) {
+      lines.push(`*${removeLines.length} items suppressed via overrides*`, "");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderDecisions(results: SourceResult[]): string {
+  const fm = makeFrontmatter({ sources: results.map((r) => r.name) });
+  const lines: string[] = [fm, "# Recent Decisions", ""];
+
+  const decisionResults = results.filter((r) => r.target === "decisions" && r.items.length > 0);
+
+  const today = new Date().toISOString().split("T")[0];
+  lines.push(`## ${today}`);
+
+  for (const result of decisionResults) {
+    for (const item of result.items) {
+      const i = item as Record<string, unknown>;
+      const title = i.title || i.decision || i.description || "Unknown";
+      const meeting = i.meeting_title || i.meeting || "";
+      lines.push(`- **${title}**${meeting ? `\n  Meeting: ${meeting}` : ""}\n  Source: ${result.name}`);
+    }
+  }
+
+  if (decisionResults.length === 0) {
+    lines.push("- (No new decisions from sources)");
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderState(results: SourceResult[]): Record<string, string> {
+  const stateFiles: Record<string, string> = {};
+  const stateResults = results.filter((r) => r.target === "state" && r.items.length > 0);
+
+  // Group by repo
+  const byRepo = new Map<string, unknown[]>();
+  for (const result of stateResults) {
+    for (const item of result.items) {
+      const i = item as Record<string, unknown>;
+      const repo = (i.repo || i.repository || "unknown") as string;
+      if (!byRepo.has(repo)) byRepo.set(repo, []);
+      byRepo.get(repo)!.push(item);
+    }
+  }
+
+  for (const [repo, items] of byRepo) {
+    const fm = makeFrontmatter({ sources: ["github"] });
+    const lines = [fm, `# ${repo}`, "", "## Open Items"];
+    for (const item of items) {
+      const i = item as Record<string, unknown>;
+      const num = i.number || "";
+      const title = i.title || "";
+      const labels = Array.isArray(i.labels) ? i.labels.map((l: any) => l.name || l).join(", ") : "";
+      lines.push(`- #${num} — ${title}${labels ? ` [${labels}]` : ""}`);
+    }
+    lines.push("");
+    stateFiles[`${repo}.md`] = lines.join("\n");
+  }
+
+  return stateFiles;
+}
+
+function writeSourcesMetadata(results: SourceResult[]): void {
+  const briefDir = getBriefDir();
+  const lines = results.map((r) => {
+    const status = r.error ? "error" : "healthy";
+    return `${r.name}: last_success=${new Date().toISOString()} status=${status} items=${r.items.length} duration=${r.duration}ms${r.error ? ` error="${r.error}"` : ""}`;
+  });
+  writeFileSync(join(briefDir, FILES.sources), lines.join("\n"));
+}
+
+export async function syncCommand(): Promise<void> {
+  const briefDir = getBriefDir();
+
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  const config = loadConfig();
+
+  if (config.sources.length === 0) {
+    console.log(chalk.yellow("  No sources configured in brief.toml. Add sources to sync from.\n"));
+    return;
+  }
+
+  console.log(chalk.dim(`  Syncing from ${config.sources.length} source(s)...`));
+
+  // Run all sources in parallel
+  const results = await Promise.all(config.sources.map(runSource));
+
+  // Report source results
+  for (const r of results) {
+    if (r.error) {
+      console.log(chalk.yellow(`  ⚠ ${r.name}: failed (${r.error})`));
+    } else {
+      console.log(chalk.dim(`  ✓ ${r.name}: ${r.items.length} items (${r.duration}ms)`));
+    }
+  }
+
+  // Render files
+  const priorities = renderPriorities(results, config);
+  writeFileSync(join(briefDir, FILES.priorities), priorities);
+
+  const decisions = renderDecisions(results);
+  writeFileSync(join(briefDir, FILES.decisions), decisions);
+
+  // Render state files
+  const stateDir = join(briefDir, DIRS.state);
+  mkdirSync(stateDir, { recursive: true });
+  const stateFiles = renderState(results);
+  for (const [filename, content] of Object.entries(stateFiles)) {
+    writeFileSync(join(stateDir, filename), content);
+  }
+
+  // Write source health metadata
+  writeSourcesMetadata(results);
+
+  // Update hash
+  writeHash(computeHash());
+
+  const total = results.reduce((sum, r) => sum + r.items.length, 0);
+  console.log(chalk.green(`\n  ✓ Brief synced. ${total} items from ${results.length} sources.\n`));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import { readCommand } from "./cli/read.js";
 import { statusCommand } from "./cli/status.js";
 import { snippetCommand } from "./cli/snippet.js";
 import { urgentCommand } from "./cli/urgent.js";
+import { syncCommand } from "./cli/sync.js";
+import { doctorCommand } from "./cli/doctor.js";
+import { assignCommand } from "./cli/assign.js";
+import { decisionCommand } from "./cli/decision.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
@@ -53,6 +57,26 @@ program
   .command("snippet [tool]")
   .description("Generate integration snippet for AI tools (claude, codex, cursor, openclaw)")
   .action(snippetCommand);
+
+program
+  .command("sync")
+  .description("Pull from configured sources and regenerate .brief/ files")
+  .action(syncCommand);
+
+program
+  .command("doctor")
+  .description("Check source health, stale files, config issues")
+  .action(doctorCommand);
+
+program
+  .command("assign <person> <item>")
+  .description("Assign a person to an item")
+  .action(assignCommand);
+
+program
+  .command("decision <description>")
+  .description("Log a decision manually")
+  .action(decisionCommand);
 
 program
   .command("urgent <message>")

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -26,7 +26,6 @@ export function loadConfig(base: string = process.cwd()): BriefConfig {
   for (const path of candidates) {
     if (existsSync(path)) {
       try {
-        // Simple TOML parsing for the fields we need
         const raw = readFileSync(path, "utf-8");
         const config = { ...DEFAULT_CONFIG };
 
@@ -39,6 +38,25 @@ export function loadConfig(base: string = process.cwd()): BriefConfig {
 
         const chatMatch = raw.match(/telegram_chat_id\s*=\s*"([^"]*)"/);
         if (chatMatch) config.notify.telegram_chat_id = chatMatch[1];
+
+        // Parse stale threshold
+        const staleMatch = raw.match(/stale_threshold_hours\s*=\s*(\d+)/);
+        if (staleMatch) config.health.stale_threshold_hours = parseInt(staleMatch[1], 10);
+
+        // Parse sources (TOML array of tables)
+        const sourceBlocks = raw.matchAll(/\[\[sources\]\]\s*\n([\s\S]*?)(?=\[\[|\[(?!\[)|$)/g);
+        config.sources = [];
+        for (const match of sourceBlocks) {
+          const block = match[1];
+          const name = block.match(/name\s*=\s*"([^"]*)"/)?.[1] || "";
+          const type = block.match(/type\s*=\s*"([^"]*)"/)?.[1] || "";
+          const command = block.match(/command\s*=\s*"([^"]*)"/)?.[1];
+          const srcPath = block.match(/path\s*=\s*"([^"]*)"/)?.[1];
+          const target = block.match(/target\s*=\s*"([^"]*)"/)?.[1] || "priorities";
+          const priority = parseInt(block.match(/priority\s*=\s*(\d+)/)?.[1] || "0", 10);
+          const timeout = parseInt(block.match(/timeout\s*=\s*(\d+)/)?.[1] || "15", 10);
+          config.sources.push({ name, type, command, path: srcPath, target, priority, timeout });
+        }
 
         return config;
       } catch {


### PR DESCRIPTION
Closes #10, #11, #12, #13, #14, #15

## New commands
- `brief sync` — pulls from configured sources, renders priorities/decisions/state
- `brief doctor` — source health, config check, notifications status
- `brief assign kevin nora-rls` — creates/updates people/kevin.md
- `brief decision "switched to JWT"` — appends to decisions.md

## Sync engine
- TOML `[[sources]]` parsing with priority/timeout/target fields
- Parallel source execution with per-source timeouts
- Cached fallback on source failure
- Source conflict resolution via priority ordering
- `.sources` metadata for health tracking

## Tested
- Scope as source: 8 items synced in 3.4s
- 13 existing tests still passing