### PR TITLE
feat: Brief v0.4 — graph, agent log, overrides, migrate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fureworks/brief",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Team working memory for AI agents and humans.",
   "main": "index.js",
   "directories": {

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -1,0 +1,82 @@
+import chalk from "chalk";
+import { existsSync } from "node:fs";
+import { getBriefDir } from "../store/paths.js";
+import { loadGraph, saveGraph, queryGraph, GraphLink } from "../store/graph.js";
+
+interface GraphOptions {
+  json?: boolean;
+}
+
+export async function graphCommand(args: string[], options: GraphOptions): Promise<void> {
+  const briefDir = getBriefDir();
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  // brief graph add <type> <from> <to>
+  if (args[0] === "add" && args.length >= 4) {
+    const type = args[1] as GraphLink["type"];
+    const from = args[2];
+    const to = args[3];
+
+    if (!["blocks", "caused_by", "related_to", "supersedes"].includes(type)) {
+      console.log(chalk.red(`  Invalid relationship type: ${type}`));
+      console.log(chalk.dim("  Valid: blocks, caused_by, related_to, supersedes\n"));
+      process.exit(1);
+    }
+
+    const links = loadGraph();
+    links.push({ from, to, type, added: new Date().toISOString().split("T")[0] });
+    saveGraph(links);
+    console.log(chalk.green(`  ✓ ${from} ${type} ${to}\n`));
+    return;
+  }
+
+  // brief graph query <item>
+  if (args[0] === "query" && args[1]) {
+    const links = loadGraph();
+    const related = queryGraph(args[1], links);
+
+    if (options.json) {
+      console.log(JSON.stringify(related, null, 2));
+      return;
+    }
+
+    if (related.length === 0) {
+      console.log(chalk.dim(`  No relationships found for ${args[1]}\n`));
+      return;
+    }
+
+    console.log("");
+    console.log(chalk.bold(`  ${args[1]}`));
+    console.log(chalk.dim("  " + "─".repeat(args[1].length)));
+    for (const link of related) {
+      const direction = link.from === args[1] ? `→ ${link.type} → ${link.to}` : `← ${link.type} ← ${link.from}`;
+      console.log(`  ${direction} (${chalk.dim(link.added)})`);
+    }
+    console.log("");
+    return;
+  }
+
+  // brief graph (show all)
+  const links = loadGraph();
+
+  if (options.json) {
+    console.log(JSON.stringify(links, null, 2));
+    return;
+  }
+
+  if (links.length === 0) {
+    console.log(chalk.dim("  No relationships found. Use 'brief graph add <type> <from> <to>' to create one.\n"));
+    return;
+  }
+
+  console.log("");
+  console.log(chalk.bold("  Relationships"));
+  console.log(chalk.dim("  ─────────────"));
+  for (const link of links) {
+    console.log(`  ${link.from} ${chalk.dim(link.type)} ${link.to} ${chalk.dim(`(${link.added})`)}`);
+  }
+  console.log(chalk.dim(`\n  ${links.length} relationship${links.length !== 1 ? "s" : ""}\n`));
+}

--- a/src/cli/log.ts
+++ b/src/cli/log.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { hostname } from "node:os";
+import chalk from "chalk";
+import { getBriefDir, FILES } from "../store/paths.js";
+import { loadConfig } from "../store/config.js";
+import { computeHash } from "../store/hash.js";
+
+interface LogOptions {
+  json?: boolean;
+  agent?: string;
+  action?: string;
+  reason?: string;
+}
+
+function getAgentName(options: LogOptions): string {
+  if (options.agent) return options.agent;
+  if (process.env.BRIEF_AGENT_NAME) return process.env.BRIEF_AGENT_NAME;
+  const config = loadConfig();
+  if ((config as any).agent_name) return (config as any).agent_name;
+  return `${process.env.USER || "unknown"}@${hostname()}`;
+}
+
+export async function logCommand(subcommand: string | undefined, description: string | undefined, options: LogOptions): Promise<void> {
+  const briefDir = getBriefDir();
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  const logFile = join(briefDir, FILES.agentLog);
+
+  // brief log write "description" --agent <name> --action "what was done"
+  if (subcommand === "write" && description) {
+    const agent = getAgentName(options);
+    const hash = computeHash();
+    const action = options.action || "unspecified";
+    const reason = options.reason || "";
+    const timestamp = new Date().toISOString();
+    const entry = `- ${timestamp} | ${agent} | ${description} (hash: ${hash.slice(0, 8)}) | ${action}${reason ? ` | Reason: ${reason}` : ""}\n`;
+
+    appendFileSync(logFile, entry);
+    console.log(chalk.green(`  ✓ Logged: ${agent} — ${action}\n`));
+    return;
+  }
+
+  // brief log (view)
+  if (!existsSync(logFile)) {
+    console.log(chalk.dim("  No agent actions logged yet.\n"));
+    return;
+  }
+
+  const content = readFileSync(logFile, "utf-8");
+  const entries = content.split("\n").filter((l) => l.startsWith("- "));
+
+  if (options.json) {
+    const parsed = entries.map((e) => {
+      const parts = e.slice(2).split(" | ");
+      return { timestamp: parts[0], agent: parts[1], read: parts[2], action: parts[3], reason: parts[4] };
+    });
+    console.log(JSON.stringify(parsed, null, 2));
+    return;
+  }
+
+  if (entries.length === 0) {
+    console.log(chalk.dim("  No agent actions logged yet.\n"));
+    return;
+  }
+
+  console.log("");
+  console.log(chalk.bold("  Agent Actions"));
+  console.log(chalk.dim("  ─────────────"));
+  // Show last 20 entries
+  const recent = entries.slice(-20);
+  for (const entry of recent) {
+    const parts = entry.slice(2).split(" | ");
+    const time = parts[0]?.slice(11, 19) || "";
+    const agent = parts[1] || "";
+    const action = parts[3] || "";
+    console.log(`  ${chalk.dim(time)} ${agent.padEnd(15)} ${action}`);
+  }
+  if (entries.length > 20) {
+    console.log(chalk.dim(`\n  ... and ${entries.length - 20} more`));
+  }
+  console.log("");
+}

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,58 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { getBriefDir } from "../store/paths.js";
+import { parseFrontmatter } from "../store/frontmatter.js";
+
+const CURRENT_VERSION = 1;
+
+export async function migrateCommand(): Promise<void> {
+  const briefDir = getBriefDir();
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  let migrated = 0;
+  let upToDate = 0;
+
+  function checkDir(dir: string) {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith(".md")) {
+        const filePath = join(dir, entry.name);
+        const content = readFileSync(filePath, "utf-8");
+        const { frontmatter } = parseFrontmatter(content);
+
+        if (!frontmatter) {
+          upToDate++;
+          continue;
+        }
+
+        if (frontmatter.brief_version < CURRENT_VERSION) {
+          // Apply migrations here when we have version 2+
+          // For now: just update the version number
+          const updated = content.replace(
+            `brief_version: ${frontmatter.brief_version}`,
+            `brief_version: ${CURRENT_VERSION}`
+          );
+          writeFileSync(filePath, updated);
+          migrated++;
+        } else {
+          upToDate++;
+        }
+      }
+      if (entry.isDirectory()) {
+        checkDir(join(dir, entry.name));
+      }
+    }
+  }
+
+  checkDir(briefDir);
+
+  if (migrated === 0) {
+    console.log(chalk.green(`  ✓ All files at version ${CURRENT_VERSION}. Nothing to migrate.\n`));
+  } else {
+    console.log(chalk.green(`  ✓ Migrated ${migrated} file${migrated !== 1 ? "s" : ""} to version ${CURRENT_VERSION}.\n`));
+  }
+}

--- a/src/cli/override.ts
+++ b/src/cli/override.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { getBriefDir, FILES } from "../store/paths.js";
+import { computeHash, writeHash } from "../store/hash.js";
+
+interface OverrideOptions {
+  priority?: string;
+  expires?: string;
+  reason?: string;
+}
+
+function getOverridesPath(): string {
+  return join(getBriefDir(), FILES.overrides);
+}
+
+function readOverrides(): string {
+  const path = getOverridesPath();
+  if (!existsSync(path)) return "# Overrides\n\n## Add\n\n## Remove\n\n## Boost\n";
+  return readFileSync(path, "utf-8");
+}
+
+function writeOverrides(content: string): void {
+  writeFileSync(getOverridesPath(), content);
+  writeHash(computeHash());
+}
+
+export async function overrideCommand(subcommand: string, args: string[], options: OverrideOptions): Promise<void> {
+  const briefDir = getBriefDir();
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  let content = readOverrides();
+
+  switch (subcommand) {
+    case "add": {
+      const description = args.join(" ");
+      if (!description) { console.log(chalk.red("  Usage: brief override add <description>\n")); process.exit(1); }
+      const entry = `- ${description}${options.reason ? `\n  Reason: ${options.reason}` : ""}${options.expires ? `\n  Expires: ${options.expires}` : ""}${options.priority ? `\n  Priority: ${options.priority}` : ""}`;
+      if (content.includes("## Add")) {
+        content = content.replace("## Add", `## Add\n${entry}`);
+      } else {
+        content += `\n## Add\n${entry}\n`;
+      }
+      writeOverrides(content);
+      console.log(chalk.green(`  ✓ Override added: ${description}\n`));
+      break;
+    }
+
+    case "remove": {
+      const itemId = args[0];
+      if (!itemId) { console.log(chalk.red("  Usage: brief override remove <item-id>\n")); process.exit(1); }
+      const entry = `- ${itemId}${options.reason ? `  # ${options.reason}` : ""}`;
+      if (content.includes("## Remove")) {
+        content = content.replace("## Remove", `## Remove\n${entry}`);
+      } else {
+        content += `\n## Remove\n${entry}\n`;
+      }
+      writeOverrides(content);
+      console.log(chalk.green(`  ✓ Override: ${itemId} will be suppressed\n`));
+      break;
+    }
+
+    case "boost": {
+      const itemId = args[0];
+      if (!itemId) { console.log(chalk.red("  Usage: brief override boost <item-id> --priority now|today\n")); process.exit(1); }
+      const priority = options.priority || "now";
+      const entry = `- ${itemId}\n  Priority: ${priority}`;
+      if (content.includes("## Boost")) {
+        content = content.replace("## Boost", `## Boost\n${entry}`);
+      } else {
+        content += `\n## Boost\n${entry}\n`;
+      }
+      writeOverrides(content);
+      console.log(chalk.green(`  ✓ Override: ${itemId} boosted to ${priority}\n`));
+      break;
+    }
+
+    case "list": {
+      console.log("");
+      console.log(chalk.bold("  Overrides"));
+      console.log(chalk.dim("  ─────────"));
+      const lines = content.split("\n").filter((l) => l.startsWith("- "));
+      if (lines.length === 0) {
+        console.log(chalk.dim("  (none)"));
+      }
+      for (const line of lines) {
+        console.log(`  ${line}`);
+      }
+      console.log("");
+      break;
+    }
+
+    case "clear": {
+      const itemId = args[0];
+      if (!itemId) { console.log(chalk.red("  Usage: brief override clear <item-id>\n")); process.exit(1); }
+      // Remove lines containing this item ID
+      const lines = content.split("\n");
+      const filtered = lines.filter((l) => !l.includes(itemId));
+      writeOverrides(filtered.join("\n"));
+      console.log(chalk.green(`  ✓ Cleared override for ${itemId}\n`));
+      break;
+    }
+
+    default:
+      console.log(chalk.red("  Usage: brief override <add|remove|boost|list|clear>\n"));
+      process.exit(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ import { syncCommand } from "./cli/sync.js";
 import { doctorCommand } from "./cli/doctor.js";
 import { assignCommand } from "./cli/assign.js";
 import { decisionCommand } from "./cli/decision.js";
+import { graphCommand } from "./cli/graph.js";
+import { logCommand } from "./cli/log.js";
+import { overrideCommand } from "./cli/override.js";
+import { migrateCommand } from "./cli/migrate.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
@@ -77,6 +81,34 @@ program
   .command("decision <description>")
   .description("Log a decision manually")
   .action(decisionCommand);
+
+program
+  .command("graph [args...]")
+  .description("Manage relationships between items (add, query, list)")
+  .option("--json", "Output as JSON")
+  .action(graphCommand);
+
+program
+  .command("log [subcommand] [description]")
+  .description("View or write agent action log")
+  .option("--json", "Output as JSON")
+  .option("--agent <name>", "Agent name")
+  .option("--action <action>", "Action taken")
+  .option("--reason <reason>", "Why the action was taken")
+  .action(logCommand);
+
+program
+  .command("override <subcommand> [args...]")
+  .description("Manage priority overrides (add, remove, boost, list, clear)")
+  .option("--priority <level>", "Priority: now or today")
+  .option("--expires <date>", "Expiration date (YYYY-MM-DD)")
+  .option("--reason <reason>", "Reason for override")
+  .action(overrideCommand);
+
+program
+  .command("migrate")
+  .description("Migrate .brief/ files to current schema version")
+  .action(migrateCommand);
 
 program
   .command("urgent <message>")

--- a/src/store/graph.ts
+++ b/src/store/graph.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getBriefDir } from "./paths.js";
+
+export interface GraphLink {
+  from: string;
+  to: string;
+  type: "blocks" | "caused_by" | "related_to" | "supersedes";
+  added: string;
+}
+
+const GRAPH_FILE = "graph.md";
+
+function getGraphPath(base?: string): string {
+  return join(getBriefDir(base), GRAPH_FILE);
+}
+
+export function loadGraph(base?: string): GraphLink[] {
+  const path = getGraphPath(base);
+  if (!existsSync(path)) return [];
+
+  const content = readFileSync(path, "utf-8");
+  const links: GraphLink[] = [];
+
+  for (const line of content.split("\n")) {
+    const match = line.match(/^- (\S+) (blocks|caused_by|related_to|supersedes) (\S+) \((\d{4}-\d{2}-\d{2})\)/);
+    if (match) {
+      links.push({ from: match[1], to: match[3], type: match[2] as GraphLink["type"], added: match[4] });
+    }
+  }
+
+  return links;
+}
+
+export function saveGraph(links: GraphLink[], base?: string): void {
+  const path = getGraphPath(base);
+  const lines = ["# Relationships", ""];
+  for (const link of links) {
+    lines.push(`- ${link.from} ${link.type} ${link.to} (${link.added})`);
+  }
+  lines.push("");
+  writeFileSync(path, lines.join("\n"));
+}
+
+export function queryGraph(itemId: string, links: GraphLink[]): GraphLink[] {
+  return links.filter((l) => l.from === itemId || l.to === itemId);
+}


### PR DESCRIPTION
Closes #22, #23, #24, #25

## New commands (4)
- `brief graph` — relationship links (blocks, caused_by, related_to, supersedes)
- `brief log` — agent action audit trail with BRIEF_AGENT_NAME identity
- `brief override` — add/remove/boost/list/clear priority overrides
- `brief migrate` — schema version migration

15 commands total. 13 tests passing.