### PR TITLE
feat: directory source type + post_sync hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fureworks/brief",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Team working memory for AI agents and humans.",
   "main": "index.js",
   "directories": {

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
@@ -27,6 +27,41 @@ async function runSource(source: BriefConfig["sources"][0]): Promise<SourceResul
       return { name: source.name, target: source.target, items: [{ raw: content }], duration: Date.now() - start };
     } catch (e: any) {
       return { name: source.name, target: source.target, items: [], error: e.message, duration: Date.now() - start };
+    }
+  }
+
+  if (source.type === "directory") {
+    try {
+      const dirPath = (source.path || "").replace(/^~/, process.env.HOME || "");
+      if (!existsSync(dirPath)) {
+        return { name: source.name, target: source.target, items: [], error: `Directory not found: ${dirPath}`, duration: Date.now() - start };
+      }
+
+      const items: unknown[] = [];
+      // If specific files listed, read only those
+      const filesToRead = (source as any).files as string[] | undefined;
+
+      if (filesToRead) {
+        for (const file of filesToRead) {
+          const filePath = join(dirPath, file);
+          if (existsSync(filePath)) {
+            const content = readFileSync(filePath, "utf-8");
+            items.push({ raw: content, file, source: source.name });
+          }
+        }
+      } else {
+        // Read all .md files in the directory (non-recursive)
+        for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+          if (entry.isFile() && entry.name.endsWith(".md")) {
+            const content = readFileSync(join(dirPath, entry.name), "utf-8");
+            items.push({ raw: content, file: entry.name, source: source.name });
+          }
+        }
+      }
+
+      return { name: source.name, target: source.target, items, duration: Date.now() - start };
+    } catch (e: any) {
+      return { name: source.name, target: source.target, items: [], error: e.message?.slice(0, 100), duration: Date.now() - start };
     }
   }
 
@@ -291,5 +326,24 @@ export async function syncCommand(): Promise<void> {
   writeHash(computeHash());
 
   const total = results.reduce((sum, r) => sum + r.items.length, 0);
-  console.log(chalk.green(`\n  ✓ Brief synced. ${total} items from ${results.length} sources.\n`));
+  console.log(chalk.green(`\n  ✓ Brief synced. ${total} items from ${results.length} sources.`));
+
+  // Run post_sync hook if configured
+  if (config.hooks?.post_sync) {
+    console.log(chalk.dim(`  Running post_sync hook...`));
+    try {
+      const { stdout, stderr } = await execAsync(config.hooks.post_sync, {
+        timeout: 60000,
+        encoding: "utf-8",
+        cwd: process.cwd(),
+      });
+      if (stdout.trim()) console.log(chalk.dim(`  ${stdout.trim()}`));
+      if (stderr.trim()) console.log(chalk.yellow(`  ${stderr.trim()}`));
+      console.log(chalk.green(`  ✓ Post-sync hook completed.`));
+    } catch (e: any) {
+      console.log(chalk.yellow(`  ⚠ Post-sync hook failed: ${e.message?.slice(0, 80)}`));
+    }
+  }
+
+  console.log("");
 }

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -3,9 +3,10 @@ import { join } from "node:path";
 
 export interface BriefConfig {
   brief: { version: number; maintainer?: string; team_repo?: string };
-  sources: Array<{ name: string; type: string; command?: string; path?: string; target: string; priority: number; timeout?: number; mapping?: Record<string, string> }>;
+  sources: Array<{ name: string; type: string; command?: string; path?: string; target: string; priority: number; timeout?: number; mapping?: Record<string, string>; files?: string[] }>;
   notify: { enabled: boolean; telegram_bot_token?: string; telegram_chat_id?: string };
   health: { stale_threshold_hours: number; source_failure_threshold: number };
+  hooks: { post_sync?: string };
 }
 
 const DEFAULT_CONFIG: BriefConfig = {
@@ -13,6 +14,7 @@ const DEFAULT_CONFIG: BriefConfig = {
   sources: [],
   notify: { enabled: false },
   health: { stale_threshold_hours: 4, source_failure_threshold: 2 },
+  hooks: {},
 };
 
 export function loadConfig(base: string = process.cwd()): BriefConfig {
@@ -55,6 +57,13 @@ export function loadConfig(base: string = process.cwd()): BriefConfig {
           const target = block.match(/target\s*=\s*"([^"]*)"/)?.[1] || "priorities";
           const priority = parseInt(block.match(/priority\s*=\s*(\d+)/)?.[1] || "0", 10);
           const timeout = parseInt(block.match(/timeout\s*=\s*(\d+)/)?.[1] || "15", 10);
+          // Parse files array if present
+          const filesMatch = block.match(/files\s*=\s*\[([^\]]*)\]/);
+          let files: string[] | undefined;
+          if (filesMatch) {
+            files = filesMatch[1].match(/"([^"]*)"/g)?.map((s) => s.replace(/"/g, "")) || [];
+          }
+
           // Parse mapping if present
           const mappingMatch = block.match(/mapping\s*=\s*\{([^}]*)\}/);
           let mapping: Record<string, string> | undefined;
@@ -65,8 +74,12 @@ export function loadConfig(base: string = process.cwd()): BriefConfig {
               mapping[pair[1]] = pair[2];
             }
           }
-          config.sources.push({ name, type, command, path: srcPath, target, priority, timeout, mapping });
+          config.sources.push({ name, type, command, path: srcPath, target, priority, timeout, mapping, files });
         }
+
+        // Parse hooks
+        const postSyncMatch = raw.match(/\[hooks\][\s\S]*?post_sync\s*=\s*"([^"]*)"/);
+        if (postSyncMatch) config.hooks = { post_sync: postSyncMatch[1] };
 
         return config;
       } catch {


### PR DESCRIPTION
Scout feedback: needs KB directory scanning + enrichment hook.

- `type = "directory"` source with optional `files = [...]` filter
- `[hooks] post_sync = "command"` runs after sync completes
- Enables: sync → pull KB → hook fires agent enrichment