### PR TITLE
fix: graph.md frontmatter + ENRICH.md clarification (#40)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fureworks/brief",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Team working memory for AI agents and humans.",
   "main": "index.js",
   "directories": {

--- a/skills/brief/ENRICH.md
+++ b/skills/brief/ENRICH.md
@@ -23,7 +23,15 @@ brief read priorities          # see what sync produced
 
 ### 2. Gather context sources
 
-Read these (adjust paths to your setup):
+After sync, all source content is available in `.brief/`. Read the synced files first — they contain KB and pipeline data pulled by directory sources:
+
+```bash
+brief read priorities          # scope items + KB items (raw, not cross-referenced)
+brief read decisions           # meeting decisions
+brief read state/project-c     # project state if generated
+```
+
+Then read additional context directly if needed:
 
 ```bash
 # Knowledge base — product priorities, roadmap, delivery tracker

--- a/src/store/graph.ts
+++ b/src/store/graph.ts
@@ -34,7 +34,16 @@ export function loadGraph(base?: string): GraphLink[] {
 
 export function saveGraph(links: GraphLink[], base?: string): void {
   const path = getGraphPath(base);
-  const lines = ["# Relationships", ""];
+  const lines = [
+    "---",
+    "brief_version: 1",
+    `updated: ${new Date().toISOString()}`,
+    "sources: [manual]",
+    "---",
+    "",
+    "# Relationships",
+    "",
+  ];
   for (const link of links) {
     lines.push(`- ${link.from} ${link.type} ${link.to} (${link.added})`);
   }


### PR DESCRIPTION
Fixes from Scout field test #40:
- graph.md now has proper frontmatter (fixes validate failure)
- ENRICH.md clarifies that synced content is available via brief read