### PR TITLE
feat: Brief v0.6 — enrichment engine

### DIFF
--- a/docs/superpowers/specs/2026-03-30-enrichment-engine-design.md
+++ b/docs/superpowers/specs/2026-03-30-enrichment-engine-design.md
@@ -1,0 +1,177 @@
+# Brief Enrichment Engine — Design Spec
+
+**Date:** 2026-03-30
+**Status:** Approved for implementation
+
+## Problem
+
+Scout's nightly cycle spends 15+ minutes gathering context before working. Brief has the raw signals but:
+1. Agent doesn't know when enrichment is stale vs current
+2. Agent doesn't know what files to read for enrichment
+3. Agent doesn't know what rules to follow
+4. Different agents need different views of the same data
+5. Re-enrichment happens even when raw data hasn't changed (token waste)
+
+## Solution
+
+Add three capabilities to Brief:
+
+### 1. Enrichment Staleness Detection
+
+Track the relationship between `priorities-raw.md` and `priorities.md`:
+
+```
+.brief/.enrichment-state
+```
+
+Contains:
+```json
+{
+  "raw_hash": "abc123",
+  "enriched_at": "2026-03-30T17:55:00Z",
+  "enriched_from_raw_hash": "abc123",
+  "agent": "scout"
+}
+```
+
+New command:
+```bash
+brief check --enrichment
+# Exit codes:
+# 0 = enrichment is current (raw hash matches)
+# 1 = enrichment is stale (raw updated since last enrichment)
+# 3 = no brief found
+```
+
+When `brief sync` updates `priorities-raw.md`, the raw hash changes. Next `brief check --enrichment` detects the mismatch → agent knows to re-enrich.
+
+After enrichment, agent runs:
+```bash
+brief enrich-done
+# Updates .enrichment-state with current raw hash + timestamp
+```
+
+### 2. Enrichment Config in brief.toml
+
+```toml
+[enrichment]
+# Files the enrichment agent should read for context
+context_files = [
+  "~/repos/team-kb/DELIVERY-TRACKER.md",
+  "~/repos/team-kb/dashboards/product-kpis.md",
+  "~/shared-knowledge/partnerships/pipeline-status.md",
+]
+
+# GitHub repos to check for merge readiness
+github_repos = [
+  "org/project-a",
+  "org/project-b",
+  "org/project-c",
+]
+github_fields = "number,title,reviewDecision,mergeable,labels"
+
+# Natural language rules the enrichment agent follows
+rules = """
+1. Cross-reference scope items against DELIVERY-TRACKER for product priority
+2. Check pipeline for deals that depend on dev work
+3. Mark APPROVED+MERGEABLE PRs as merge-now
+4. Group by: URGENT (compliance/security), NOW (revenue-critical), TODAY (operational)
+5. Remove parked items from NOW — staleness alone is not urgency
+"""
+```
+
+New command:
+```bash
+brief enrich-context
+# Outputs all context files + github data + rules
+# Agent pipes this into their enrichment prompt
+```
+
+This replaces "agent has to discover ENRICH.md and improvise." The config declares everything.
+
+### 3. Per-Agent Views
+
+```toml
+[agents.scout]
+focus = ["github-prs", "github-issues", "ci-status", "compliance"]
+hide = ["pipeline-details", "content-calendar"]
+
+[agents.reed]
+focus = ["pipeline", "partner-meetings", "deal-blockers", "revenue"]
+hide = ["pr-numbers", "ci-status"]
+```
+
+New command:
+```bash
+brief read priorities --agent scout
+# Filters priorities.md sections based on agent's focus/hide config
+# Falls back to full file if no agent config found
+```
+
+## Architecture
+
+### New files:
+- `src/store/enrichment.ts` — enrichment state tracking (read/write .enrichment-state)
+- `src/cli/enrich-context.ts` — outputs enrichment context for agents
+- Modify `src/cli/check.ts` — add `--enrichment` flag
+- Modify `src/cli/read.ts` — add `--agent` flag
+- Modify `src/store/config.ts` — parse `[enrichment]` and `[agents.*]` sections
+
+### New .brief/ file:
+- `.enrichment-state` — JSON tracking raw hash vs enrichment hash
+
+### Config additions:
+```toml
+[enrichment]
+context_files = [...]
+github_repos = [...]
+github_fields = "..."
+rules = """..."""
+
+[agents.NAME]
+focus = [...]
+hide = [...]
+```
+
+## CLI Changes
+
+```bash
+# Enrichment staleness
+brief check --enrichment       # is enrichment current?
+brief enrich-done              # mark enrichment as complete
+
+# Enrichment context
+brief enrich-context           # output all context for enrichment agent
+brief enrich-context --json    # machine-readable
+
+# Per-agent view
+brief read priorities --agent scout
+brief read priorities --agent reed
+```
+
+## Agent Workflow (after these changes)
+
+```
+# Pre-flight (cheap model)
+brief sync                          # pull raw signals
+brief check --enrichment            # is enrichment stale?
+  exit 0 → skip enrichment, use existing priorities.md
+  exit 1 → run enrichment:
+    context=$(brief enrich-context)  # get all context + rules
+    [agent reads context, writes enriched priorities.md]
+    brief enrich-done               # mark enrichment complete
+
+# Work session (expensive model)
+brief read priorities --agent scout  # filtered view
+[work on item #1]
+brief log write ...
+```
+
+15 minutes of context gathering → 30 seconds of brief commands.
+
+## What this does NOT do
+
+- Brief does NOT run the LLM. The agent does.
+- Brief does NOT interpret enrichment rules. They're natural language for the agent.
+- Brief does NOT decide what to work on. It provides context. The agent decides.
+- Brief stays infrastructure. The agent stays intelligence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fureworks/brief",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fureworks/brief",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Team working memory for AI agents and humans.",
   "main": "index.js",
   "directories": {

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,8 +1,27 @@
 import { existsSync } from "node:fs";
 import { getBriefDir } from "../store/paths.js";
 import { computeHash, readStoredHash, writeHash, hasUrgent } from "../store/hash.js";
+import { isEnrichmentStale } from "../store/enrichment.js";
 
-export async function checkCommand(): Promise<void> {
+interface CheckOptions {
+  enrichment?: boolean;
+}
+
+export async function checkCommand(options: CheckOptions): Promise<void> {
+  // Enrichment mode: separate exit codes
+  if (options.enrichment) {
+    const briefDir = getBriefDir();
+    if (!existsSync(briefDir)) {
+      process.stdout.write("error: no brief found\n");
+      process.exit(3);
+    }
+    if (await isEnrichmentStale()) {
+      process.stdout.write("stale: enrichment needs update\n");
+      process.exit(5);
+    }
+    process.stdout.write("ok: enrichment current\n");
+    process.exit(0);
+  }
   const briefDir = getBriefDir();
 
   if (!existsSync(briefDir)) {

--- a/src/cli/enrich-context.ts
+++ b/src/cli/enrich-context.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import chalk from "chalk";
+import { getBriefDir, FILES } from "../store/paths.js";
+import { loadConfig } from "../store/config.js";
+
+const execAsync = promisify(exec);
+
+interface EnrichContextOptions {
+  json?: boolean;
+}
+
+export async function enrichContextCommand(options: EnrichContextOptions): Promise<void> {
+  const briefDir = getBriefDir();
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    process.exit(3);
+  }
+
+  const config = loadConfig();
+  const enrichment = (config as any).enrichment as {
+    context_files?: string[];
+    github_repos?: string[];
+    github_fields?: string;
+    rules?: string;
+    owner?: string;
+  } | undefined;
+
+  if (!enrichment) {
+    console.log(chalk.yellow("  No [enrichment] section in brief.toml.\n"));
+    process.exit(1);
+  }
+
+  const result: {
+    raw_priorities: string;
+    context_files: Array<{ path: string; content: string }>;
+    github: Array<{ repo: string; items: unknown[] }>;
+    rules: string;
+    overrides: string;
+  } = {
+    raw_priorities: "",
+    context_files: [],
+    github: [],
+    rules: enrichment.rules || "",
+    overrides: "",
+  };
+
+  // Read raw priorities
+  const rawFile = join(briefDir, FILES.prioritiesRaw);
+  if (existsSync(rawFile)) {
+    result.raw_priorities = readFileSync(rawFile, "utf-8");
+  }
+
+  // Read overrides
+  const overridesFile = join(briefDir, FILES.overrides);
+  if (existsSync(overridesFile)) {
+    result.overrides = readFileSync(overridesFile, "utf-8");
+  }
+
+  // Read context files
+  if (enrichment.context_files) {
+    for (const filePath of enrichment.context_files) {
+      const resolved = filePath.replace(/^~/, process.env.HOME || "");
+      if (existsSync(resolved)) {
+        result.context_files.push({
+          path: filePath,
+          content: readFileSync(resolved, "utf-8"),
+        });
+      }
+    }
+  }
+
+  // Pull GitHub data
+  if (enrichment.github_repos) {
+    const fields = enrichment.github_fields || "number,title,reviewDecision,mergeable,labels";
+    for (const repo of enrichment.github_repos) {
+      try {
+        const { stdout } = await execAsync(
+          `gh pr list --repo ${repo} --state open --json ${fields} --limit 20`,
+          { encoding: "utf-8", timeout: 10000 }
+        );
+        result.github.push({ repo, items: JSON.parse(stdout) });
+      } catch {
+        result.github.push({ repo, items: [] });
+      }
+    }
+  }
+
+  // Output
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Structured markdown output
+  console.log("# Enrichment Context\n");
+
+  console.log("## Raw Priorities (from brief sync)\n");
+  console.log(result.raw_priorities);
+
+  if (result.overrides.trim()) {
+    console.log("\n## Overrides\n");
+    console.log(result.overrides);
+  }
+
+  if (result.context_files.length > 0) {
+    console.log("\n## Context Files\n");
+    for (const cf of result.context_files) {
+      console.log(`### ${cf.path}\n`);
+      console.log(cf.content);
+      console.log("");
+    }
+  }
+
+  if (result.github.length > 0) {
+    console.log("\n## GitHub PR State\n");
+    for (const gh of result.github) {
+      console.log(`### ${gh.repo} (${(gh.items as any[]).length} PRs)\n`);
+      for (const pr of gh.items as any[]) {
+        const decision = pr.reviewDecision || "none";
+        const mergeable = pr.mergeable || "unknown";
+        const labels = (pr.labels || []).map((l: any) => l.name || l).join(", ");
+        console.log(`- #${pr.number} ${pr.title} [${decision}, ${mergeable}]${labels ? ` {${labels}}` : ""}`);
+      }
+      console.log("");
+    }
+  }
+
+  if (result.rules) {
+    console.log("\n## Enrichment Rules\n");
+    console.log(result.rules);
+  }
+
+  console.log("\n---");
+  console.log("Use this context to rewrite .brief/priorities.md with cross-referenced priorities.");
+  console.log("After enrichment, run: brief enrich-done");
+}

--- a/src/cli/enrich-done.ts
+++ b/src/cli/enrich-done.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import { hostname } from "node:os";
+import chalk from "chalk";
+import { getBriefDir } from "../store/paths.js";
+import { markEnrichmentDone, loadEnrichmentState } from "../store/enrichment.js";
+import { loadConfig } from "../store/config.js";
+
+export async function enrichDoneCommand(): Promise<void> {
+  const briefDir = getBriefDir();
+  if (!existsSync(briefDir)) {
+    console.log(chalk.red("  No .brief/ directory found.\n"));
+    process.exit(3);
+  }
+
+  // Determine agent name
+  const agent = process.env.BRIEF_AGENT_NAME
+    || (loadConfig() as any).enrichment?.owner
+    || `${process.env.USER || "unknown"}@${hostname()}`;
+
+  // Check ownership
+  const existing = loadEnrichmentState();
+  if (existing && existing.owner && existing.owner !== agent) {
+    console.log(chalk.yellow(`  ⚠ Enrichment owned by ${existing.owner}, not ${agent}. Proceeding anyway.\n`));
+  }
+
+  markEnrichmentDone(agent);
+  console.log(chalk.green(`  ✓ Enrichment marked complete by ${agent}\n`));
+}

--- a/src/cli/read.ts
+++ b/src/cli/read.ts
@@ -3,7 +3,11 @@ import { join } from "node:path";
 import chalk from "chalk";
 import { getBriefDir } from "../store/paths.js";
 
-export async function readCommand(file?: string): Promise<void> {
+interface ReadOptions {
+  agent?: string;
+}
+
+export async function readCommand(file: string | undefined, options: ReadOptions): Promise<void> {
   const briefDir = getBriefDir();
 
   if (!existsSync(briefDir)) {
@@ -41,7 +45,53 @@ export async function readCommand(file?: string): Promise<void> {
     process.exit(1);
   }
 
-  process.stdout.write(readFileSync(filePath, "utf-8"));
+  let content = readFileSync(filePath, "utf-8");
+
+  // Per-agent filtering
+  if (options.agent) {
+    const config = (await import("../store/config.js")).loadConfig();
+    const agents = (config as any).agents as Record<string, { focus?: string[]; hide?: string[] }> | undefined;
+    const agentConfig = agents?.[options.agent];
+
+    if (agentConfig) {
+      const lines = content.split("\n");
+      const filtered: string[] = [];
+      let currentSection = "";
+      let includeSection = true;
+
+      for (const line of lines) {
+        if (line.startsWith("## ")) {
+          currentSection = line.toLowerCase();
+          const hide = agentConfig.hide || [];
+          const focus = agentConfig.focus || [];
+
+          if (hide.length > 0) {
+            includeSection = !hide.some((h) => currentSection.includes(h.toLowerCase()));
+          } else if (focus.length > 0) {
+            includeSection = focus.some((f) => currentSection.includes(f.toLowerCase()));
+          } else {
+            includeSection = true;
+          }
+        }
+
+        if (line.startsWith("# ") || line.startsWith("---")) {
+          // Always include top-level headings and frontmatter
+          filtered.push(line);
+        } else if (includeSection) {
+          filtered.push(line);
+        }
+      }
+
+      content = filtered.join("\n");
+
+      if (filtered.filter((l) => l.startsWith("- ")).length === 0) {
+        process.stderr.write(`warning: no items matched agent '${options.agent}' focus/hide — showing full file\n`);
+        content = readFileSync(filePath, "utf-8");
+      }
+    }
+  }
+
+  process.stdout.write(content);
 }
 
 function listDir(dir: string, prefix: string): void {

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -360,6 +360,16 @@ export async function syncCommand(): Promise<void> {
   // Update hash
   writeHash(computeHash());
 
+  // Update enrichment state raw_hash (so enrichment staleness detection works)
+  try {
+    const { loadEnrichmentState, saveEnrichmentState, getRawHash } = await import("../store/enrichment.js");
+    const state = loadEnrichmentState();
+    if (state) {
+      state.raw_hash = await getRawHash();
+      saveEnrichmentState(state);
+    }
+  } catch { /* enrichment module not critical */ }
+
   const total = results.reduce((sum, r) => sum + r.items.length, 0);
   console.log(chalk.green(`\n  ✓ Brief synced. ${total} items from ${results.length} sources.`));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import { logCommand } from "./cli/log.js";
 import { overrideCommand } from "./cli/override.js";
 import { migrateCommand } from "./cli/migrate.js";
 import { serveCommand } from "./cli/serve.js";
+import { enrichContextCommand } from "./cli/enrich-context.js";
+import { enrichDoneCommand } from "./cli/enrich-done.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
@@ -46,11 +48,13 @@ program
 program
   .command("check")
   .description("Hash-based change detection (for agents)")
+  .option("--enrichment", "Check if enrichment is stale (exit 5=stale, 0=current)")
   .action(checkCommand);
 
 program
   .command("read [file]")
   .description("Read a .brief/ file (or list all files)")
+  .option("--agent <name>", "Filter view for specific agent (from brief.toml [agents.*])")
   .action(readCommand);
 
 program
@@ -110,6 +114,17 @@ program
   .command("migrate")
   .description("Migrate .brief/ files to current schema version")
   .action(migrateCommand);
+
+program
+  .command("enrich-context")
+  .description("Output all context needed for enrichment (files + GitHub + rules)")
+  .option("--json", "Output as JSON")
+  .action(enrichContextCommand);
+
+program
+  .command("enrich-done")
+  .description("Mark enrichment as complete (updates staleness tracking)")
+  .action(enrichDoneCommand);
 
 program
   .command("serve")

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -81,6 +81,40 @@ export function loadConfig(base: string = process.cwd()): BriefConfig {
         const postSyncMatch = raw.match(/\[hooks\][\s\S]*?post_sync\s*=\s*"([^"]*)"/);
         if (postSyncMatch) config.hooks = { post_sync: postSyncMatch[1] };
 
+        // Parse enrichment section
+        const enrichSection = raw.match(/\[enrichment\]([\s\S]*?)(?=\n\[(?!\[)|$)/);
+        if (enrichSection) {
+          const block = enrichSection[1];
+          const ctxFiles = block.match(/context_files\s*=\s*\[([\s\S]*?)\]/);
+          const ghRepos = block.match(/github_repos\s*=\s*\[([\s\S]*?)\]/);
+          const ghFields = block.match(/github_fields\s*=\s*"([^"]*)"/);
+          const rules = block.match(/rules\s*=\s*"""([\s\S]*?)"""/);
+          const owner = block.match(/owner\s*=\s*"([^"]*)"/);
+
+          (config as any).enrichment = {
+            context_files: ctxFiles ? ctxFiles[1].match(/"([^"]*)"/g)?.map((s: string) => s.replace(/"/g, "")) : [],
+            github_repos: ghRepos ? ghRepos[1].match(/"([^"]*)"/g)?.map((s: string) => s.replace(/"/g, "")) : [],
+            github_fields: ghFields?.[1] || "number,title,reviewDecision,mergeable,labels",
+            rules: rules?.[1]?.trim() || "",
+            owner: owner?.[1] || "",
+          };
+        }
+
+        // Parse agent views
+        const agentSections = raw.matchAll(/\[agents\.(\w+)\]\s*\n([\s\S]*?)(?=\[|$)/g);
+        const agents: Record<string, { focus?: string[]; hide?: string[] }> = {};
+        for (const match of agentSections) {
+          const name = match[1];
+          const block = match[2];
+          const focus = block.match(/focus\s*=\s*\[([\s\S]*?)\]/);
+          const hide = block.match(/hide\s*=\s*\[([\s\S]*?)\]/);
+          agents[name] = {
+            focus: focus ? focus[1].match(/"([^"]*)"/g)?.map((s: string) => s.replace(/"/g, "")) : undefined,
+            hide: hide ? hide[1].match(/"([^"]*)"/g)?.map((s: string) => s.replace(/"/g, "")) : undefined,
+          };
+        }
+        if (Object.keys(agents).length > 0) (config as any).agents = agents;
+
         return config;
       } catch {
         return DEFAULT_CONFIG;

--- a/src/store/enrichment.ts
+++ b/src/store/enrichment.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getBriefDir } from "./paths.js";
+import { computeHash } from "./hash.js";
+
+const STATE_FILE = ".enrichment-state";
+
+export interface EnrichmentState {
+  schema_version: number;
+  raw_hash: string;
+  enriched_at: string;
+  enriched_from_raw_hash: string;
+  owner: string;
+}
+
+function getStatePath(base?: string): string {
+  return join(getBriefDir(base), STATE_FILE);
+}
+
+export function loadEnrichmentState(base?: string): EnrichmentState | null {
+  const path = getStatePath(base);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export function saveEnrichmentState(state: EnrichmentState, base?: string): void {
+  writeFileSync(getStatePath(base), JSON.stringify(state, null, 2));
+}
+
+export async function getRawHash(base?: string): Promise<string> {
+  const briefDir = getBriefDir(base);
+  const rawFile = join(briefDir, "priorities-raw.md");
+  if (!existsSync(rawFile)) return "";
+  const crypto = await import("node:crypto");
+  return crypto.createHash("sha256").update(readFileSync(rawFile)).digest("hex").slice(0, 16);
+}
+
+export async function isEnrichmentStale(base?: string): Promise<boolean> {
+  const state = loadEnrichmentState(base);
+  if (!state) return true;
+  const currentRawHash = await getRawHash(base);
+  return state.enriched_from_raw_hash !== currentRawHash;
+}
+
+export async function markEnrichmentDone(agent: string, base?: string): Promise<void> {
+  const rawHash = await getRawHash(base);
+  const state: EnrichmentState = {
+    schema_version: 1,
+    raw_hash: rawHash,
+    enriched_at: new Date().toISOString(),
+    enriched_from_raw_hash: rawHash,
+    owner: agent,
+  };
+  saveEnrichmentState(state, base);
+}


### PR DESCRIPTION
Scout's core requests:

1. ✅ **Enrichment staleness**: `brief check --enrichment` (exit 0=current, 5=stale)
2. ✅ **Enrichment config**: `[enrichment]` section with context_files, github_repos, rules, owner
3. ✅ **Per-agent views**: `brief read priorities --agent scout` filters by [agents.*] config
4. ✅ **Context output**: `brief enrich-context` gives agent everything needed to enrich
5. ✅ **Enrichment caching**: `brief enrich-done` tracks raw hash, skips re-enrichment when unchanged

18 commands. Agent workflow: sync → check --enrichment → if stale: enrich-context → write priorities.md → enrich-done