### PR TITLE
feat: add explicit brief health states

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc && cp -r src/templates dist/",
-    "test": "vitest run",
+    "test": "npm run build && vitest run",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { assessBriefHealth } from "../store/health.js";
+import { CURRENT_SCHEMA, FILES } from "../store/paths.js";
+
+function makeTestDir(name: string): string {
+  const dir = `/tmp/brief-health-${name}-${Date.now()}`;
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createCurrentSchema(dir: string, options: { stale?: boolean; unreviewedHuman?: boolean } = {}): void {
+  const briefDir = join(dir, ".brief");
+  mkdirSync(briefDir, { recursive: true });
+
+  for (const relativeDir of CURRENT_SCHEMA.requiredDirs) {
+    mkdirSync(join(briefDir, relativeDir), { recursive: true });
+  }
+
+  for (const relativeFile of CURRENT_SCHEMA.requiredFiles) {
+    const fullPath = join(briefDir, relativeFile);
+    mkdirSync(join(fullPath, ".."), { recursive: true });
+    let content = "ok\n";
+    if (relativeFile === FILES.humanPriorities) {
+      content = options.unreviewedHuman
+        ? "# Human Priorities\n\nLast reviewed: (not yet)\n"
+        : "# Human Priorities\n\nLast reviewed: 2026-04-08\nReviewer: test\n";
+    }
+    writeFileSync(fullPath, content);
+  }
+
+  const prioritiesFile = join(briefDir, FILES.priorities);
+  const rawFile = join(briefDir, FILES.prioritiesRaw);
+  utimesSync(rawFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
+  utimesSync(prioritiesFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+  if (options.stale) {
+    utimesSync(prioritiesFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
+    utimesSync(rawFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+  }
+}
+
+describe("assessBriefHealth", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("detects healthy current schema", () => {
+    const dir = makeTestDir("healthy");
+    dirs.push(dir);
+    createCurrentSchema(dir);
+
+    const report = assessBriefHealth(dir);
+    expect(report.state).toBe("healthy-current-schema");
+    expect(report.schema).toBe("current");
+  });
+
+  it("detects stale current schema", () => {
+    const dir = makeTestDir("stale");
+    dirs.push(dir);
+    createCurrentSchema(dir, { stale: true });
+
+    const report = assessBriefHealth(dir);
+    expect(report.state).toBe("stale");
+    expect(report.reasons.some((reason) => reason.includes(FILES.prioritiesRaw))).toBe(true);
+  });
+
+  it("detects legacy schema when old core files exist but current markers are missing", () => {
+    const dir = makeTestDir("legacy");
+    dirs.push(dir);
+    const briefDir = join(dir, ".brief");
+    mkdirSync(join(briefDir, "state"), { recursive: true });
+    mkdirSync(join(briefDir, "people"), { recursive: true });
+    writeFileSync(join(briefDir, FILES.priorities), "# Priorities\n");
+    writeFileSync(join(briefDir, FILES.prioritiesRaw), "# Raw\n");
+    writeFileSync(join(briefDir, FILES.decisions), "# Decisions\n");
+    writeFileSync(join(briefDir, FILES.team), "# Team\n");
+    writeFileSync(join(briefDir, FILES.overrides), "# Overrides\n");
+    writeFileSync(join(briefDir, FILES.agentLog), "# Agent Log\n");
+
+    const report = assessBriefHealth(dir);
+    expect(report.state).toBe("legacy-schema");
+    expect(report.schema).toBe("legacy");
+  });
+
+  it("detects missing brief directories", () => {
+    const dir = makeTestDir("missing");
+    dirs.push(dir);
+
+    const report = assessBriefHealth(dir);
+    expect(report.state).toBe("missing");
+  });
+
+  it("detects misconfigured brief directories", () => {
+    const dir = makeTestDir("misconfigured");
+    dirs.push(dir);
+    const briefDir = join(dir, ".brief");
+    mkdirSync(join(briefDir, "rules"), { recursive: true });
+    writeFileSync(join(briefDir, "rules", "BUILD.md"), "# Build\n");
+
+    const report = assessBriefHealth(dir);
+    expect(report.state).toBe("misconfigured");
+  });
+});

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,43 +1,47 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
 import { getBriefDir } from "../store/paths.js";
 import { computeHash, readStoredHash, writeHash, hasUrgent } from "../store/hash.js";
+import { assessBriefHealth, exitCodeForHealth } from "../store/health.js";
 
 interface CheckOptions {
   enrichment?: boolean;
+  health?: boolean;
+  json?: boolean;
+}
+
+function printHealth(options: CheckOptions, health = assessBriefHealth()): never {
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(health, null, 2)}\n`);
+  } else {
+    process.stdout.write(`health: ${health.state}\n`);
+    for (const reason of health.reasons) {
+      process.stdout.write(`- ${reason}\n`);
+    }
+  }
+  process.exit(exitCodeForHealth(health.state));
 }
 
 export async function checkCommand(options: CheckOptions): Promise<void> {
   const briefDir = getBriefDir();
+  const health = assessBriefHealth();
+
+  if (options.health) {
+    printHealth(options, health);
+  }
+
+  if (health.state === "missing" || health.state === "legacy-schema" || health.state === "misconfigured") {
+    printHealth(options, health);
+  }
 
   if (!existsSync(briefDir)) {
     process.stdout.write("error: no brief found\n");
     process.exit(3);
   }
 
-  // Enrichment mode: is PRIORITIES.md stale relative to raw/?
   if (options.enrichment) {
-    const priFile = join(briefDir, "priorities.md");
-    const rawFile = join(briefDir, "priorities-raw.md");
-
-    if (!existsSync(rawFile)) {
-      process.stdout.write("stale: no raw data — run brief fetch\n");
-      process.exit(5);
-    }
-
-    if (!existsSync(priFile)) {
-      process.stdout.write("stale: no priorities — build needed\n");
-      process.exit(5);
-    }
-
-    // Compare raw file mtime vs priorities mtime
-    const { statSync } = await import("node:fs");
-    const rawMtime = statSync(rawFile).mtimeMs;
-    const priMtime = statSync(priFile).mtimeMs;
-
-    if (rawMtime > priMtime) {
-      process.stdout.write("stale: raw data newer than priorities\n");
+    if (health.state === "stale") {
+      process.stdout.write(`stale: ${health.reasons.join(" ")}\n`);
       process.exit(5);
     }
 
@@ -45,20 +49,18 @@ export async function checkCommand(options: CheckOptions): Promise<void> {
     process.exit(0);
   }
 
-  // Check for missing PRIORITIES-HUMAN.md (interview not done)
   const humanPriFile = join(briefDir, "PRIORITIES-HUMAN.md");
   if (!existsSync(humanPriFile)) {
     process.stdout.write("missing: no PRIORITIES-HUMAN.md — run the interview first (rules/INTERVIEW.md)\n");
     process.exit(6);
   }
-  // Check if interview is stale (>7 days)
+
   const humanContent = readFileSync(humanPriFile, "utf-8");
   if (humanContent.includes("Last reviewed: (not yet)")) {
     process.stdout.write("missing: PRIORITIES-HUMAN.md not filled in — run the interview (rules/INTERVIEW.md)\n");
     process.exit(6);
   }
 
-  // Normal mode: file change detection
   const currentHash = computeHash();
   const storedHash = readStoredHash();
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -62,8 +62,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
   mkdirSync(briefDir, { recursive: true });
   mkdirSync(join(briefDir, DIRS.state), { recursive: true });
   mkdirSync(join(briefDir, DIRS.people), { recursive: true });
-  mkdirSync(join(briefDir, "rules"), { recursive: true });
-  mkdirSync(join(briefDir, "raw"), { recursive: true });
+  mkdirSync(join(briefDir, DIRS.rules), { recursive: true });
+  mkdirSync(join(briefDir, DIRS.raw), { recursive: true });
 
   // Copy rules templates — check both dist and src paths
   let templatesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "templates", "rules");
@@ -74,7 +74,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   if (existsSync(templatesDir)) {
     for (const file of readdirSync(templatesDir)) {
       const src = join(templatesDir, file);
-      const dest = join(briefDir, "rules", file);
+      const dest = join(briefDir, DIRS.rules, file);
       if (!existsSync(dest)) {
         writeFileSync(dest, readFileSync(src, "utf-8"));
       }
@@ -95,7 +95,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeFileSync(join(briefDir, FILES.sources), "");
 
   // Create blank PRIORITIES-HUMAN.md template
-  const humanPriFile = join(briefDir, "PRIORITIES-HUMAN.md");
+  const humanPriFile = join(briefDir, FILES.humanPriorities);
   if (!existsSync(humanPriFile)) {
     writeFileSync(humanPriFile, `# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: (not yet)\n\n## Product Priorities\n- P0: (run the interview — see rules/INTERVIEW.md)\n\n## Active Deals\n- (none yet)\n\n## Do NOT Work On\n- (none yet)\n\n## Blockers Needing Human Decision\n- (none yet)\n`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,10 @@ program
 
 program
   .command("check")
-  .description("Change detection for automation (exit 0=ok, 1=changed, 2=urgent, 5=enrichment stale)")
+  .description("Change detection and health inspection for automation")
   .option("--enrichment", "Check if enrichment is stale instead of file changes")
+  .option("--health", "Inspect brief health/schema state")
+  .option("--json", "Output health as JSON (use with --health)")
   .action(checkCommand);
 
 program.parse();

--- a/src/store/health.ts
+++ b/src/store/health.ts
@@ -1,0 +1,150 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { CURRENT_SCHEMA, FILES, getBriefDir } from "./paths.js";
+
+export type BriefHealthState =
+  | "healthy-current-schema"
+  | "legacy-schema"
+  | "missing"
+  | "misconfigured"
+  | "stale";
+
+export interface BriefHealthReport {
+  state: BriefHealthState;
+  schema: "current" | "legacy" | "missing" | "unknown";
+  checkedAt: string;
+  reasons: string[];
+  missingPaths: string[];
+  presentPaths: string[];
+  briefDir: string;
+}
+
+function existingPaths(baseDir: string, relativePaths: readonly string[]): string[] {
+  return relativePaths.filter((relativePath) => existsSync(join(baseDir, relativePath)));
+}
+
+function missingPaths(baseDir: string, relativePaths: readonly string[]): string[] {
+  return relativePaths.filter((relativePath) => !existsSync(join(baseDir, relativePath)));
+}
+
+function staleReasons(briefDir: string): string[] {
+  const reasons: string[] = [];
+  const prioritiesFile = join(briefDir, FILES.priorities);
+  const rawFile = join(briefDir, FILES.prioritiesRaw);
+  const humanFile = join(briefDir, FILES.humanPriorities);
+
+  if (!existsSync(rawFile)) {
+    reasons.push(`Missing ${FILES.prioritiesRaw}.`);
+  }
+
+  if (!existsSync(prioritiesFile)) {
+    reasons.push(`Missing ${FILES.priorities}.`);
+  }
+
+  if (existsSync(rawFile) && existsSync(prioritiesFile)) {
+    const rawMtime = statSync(rawFile).mtimeMs;
+    const prioritiesMtime = statSync(prioritiesFile).mtimeMs;
+    if (rawMtime > prioritiesMtime) {
+      reasons.push(`${FILES.prioritiesRaw} is newer than ${FILES.priorities}.`);
+    }
+  }
+
+  if (existsSync(humanFile)) {
+    const content = readFileSync(humanFile, "utf-8");
+    if (content.includes("Last reviewed: (not yet)")) {
+      reasons.push(`${FILES.humanPriorities} has not been reviewed yet.`);
+    }
+  }
+
+  return reasons;
+}
+
+export function assessBriefHealth(base: string = process.cwd()): BriefHealthReport {
+  const briefDir = getBriefDir(base);
+  const checkedAt = new Date().toISOString();
+
+  if (!existsSync(briefDir)) {
+    return {
+      state: "missing",
+      schema: "missing",
+      checkedAt,
+      reasons: ["No .brief/ directory found."],
+      missingPaths: [".brief/"],
+      presentPaths: [],
+      briefDir,
+    };
+  }
+
+  const requiredPaths = [...CURRENT_SCHEMA.requiredDirs, ...CURRENT_SCHEMA.requiredFiles];
+  const present = existingPaths(briefDir, requiredPaths);
+  const missing = missingPaths(briefDir, requiredPaths);
+
+  if (missing.length === 0) {
+    const stale = staleReasons(briefDir);
+    if (stale.length > 0) {
+      return {
+        state: "stale",
+        schema: "current",
+        checkedAt,
+        reasons: stale,
+        missingPaths: [],
+        presentPaths: present,
+        briefDir,
+      };
+    }
+
+    return {
+      state: "healthy-current-schema",
+      schema: "current",
+      checkedAt,
+      reasons: ["Current startup schema detected."],
+      missingPaths: [],
+      presentPaths: present,
+      briefDir,
+    };
+  }
+
+  const legacyPresent = existingPaths(briefDir, CURRENT_SCHEMA.legacySignals);
+  const missingCurrentMarkers = missingPaths(briefDir, CURRENT_SCHEMA.legacyMissingMarkers);
+  const looksLegacy = legacyPresent.length >= 3 && missingCurrentMarkers.length > 0;
+
+  if (looksLegacy) {
+    return {
+      state: "legacy-schema",
+      schema: "legacy",
+      checkedAt,
+      reasons: [
+        "Legacy brief layout detected.",
+        ...missingCurrentMarkers.map((relativePath) => `Missing current-schema marker: ${relativePath}`),
+      ],
+      missingPaths: missing,
+      presentPaths: legacyPresent,
+      briefDir,
+    };
+  }
+
+  return {
+    state: "misconfigured",
+    schema: "unknown",
+    checkedAt,
+    reasons: missing.map((relativePath) => `Missing required path: ${relativePath}`),
+    missingPaths: missing,
+    presentPaths: present,
+    briefDir,
+  };
+}
+
+export function exitCodeForHealth(state: BriefHealthState): number {
+  switch (state) {
+    case "healthy-current-schema":
+      return 0;
+    case "missing":
+      return 3;
+    case "misconfigured":
+      return 4;
+    case "stale":
+      return 5;
+    case "legacy-schema":
+      return 6;
+  }
+}

--- a/src/store/paths.ts
+++ b/src/store/paths.ts
@@ -14,9 +14,48 @@ export const FILES = {
   agentLog: "agent-log.md",
   hash: ".hash",
   sources: ".sources",
+  humanPriorities: "PRIORITIES-HUMAN.md",
 } as const;
 
 export const DIRS = {
   state: "state",
   people: "people",
+  rules: "rules",
+  raw: "raw",
+} as const;
+
+export const RULE_TEMPLATES = [
+  "BUILD.md",
+  "EVENING.md",
+  "FETCH.md",
+  "INTERVIEW.md",
+  "MORNING.md",
+  "SETUP.md",
+] as const;
+
+export const CURRENT_SCHEMA = {
+  requiredFiles: [
+    FILES.priorities,
+    FILES.prioritiesRaw,
+    FILES.decisions,
+    FILES.team,
+    FILES.overrides,
+    FILES.agentLog,
+    FILES.hash,
+    FILES.sources,
+    FILES.humanPriorities,
+    ...RULE_TEMPLATES.map((rule) => join(DIRS.rules, rule)),
+  ],
+  requiredDirs: [DIRS.state, DIRS.people, DIRS.rules, DIRS.raw],
+  legacySignals: [
+    FILES.priorities,
+    FILES.prioritiesRaw,
+    FILES.decisions,
+    FILES.team,
+    FILES.overrides,
+    FILES.agentLog,
+    DIRS.state,
+    DIRS.people,
+  ],
+  legacyMissingMarkers: [FILES.humanPriorities, join(DIRS.rules, "BUILD.md"), join(DIRS.rules, "INTERVIEW.md"), DIRS.raw],
 } as const;


### PR DESCRIPTION
## Summary
- add explicit Brief health states: healthy-current-schema, legacy-schema, missing, misconfigured, and stale
- detect schema health against a shared current-schema manifest instead of scattered path checks
- add `brief check --health` plus health-report tests so automation can tell current, legacy, stale, and broken workspaces apart

## Testing
- npm test

Closes #52
