### PR TITLE
feat: add health-aware fetch and check guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ Review `.brief/rules/INTERVIEW.md` questions. Update product priorities.
 
 **Morning (agent):**
 ```bash
+brief check --health                 # current schema, legacy, missing, broken?
 brief fetch                          # get fresh data
-brief check --enrichment             # stale? 
+brief check --enrichment             # stale?
 # If exit 5: read rules/BUILD.md + raw/ → write PRIORITIES.md
 cat .brief/PRIORITIES.md             # context for the day
 ```
+
+If `brief check --health` says `legacy-schema` or `misconfigured`, treat Brief as degraded context, not as a trusted steering layer.
 
 **During work:**
 Edit DECISIONS.md, PEOPLE.md, GRAPH.md, LOG.md as things happen.
@@ -83,7 +86,8 @@ Read `.brief/rules/EVENING.md`. Log what was done. Commit.
 2. **3 commands.** init, fetch, check. Everything else is files.
 3. **Rules in markdown.** Agents read rules/ and follow them.
 4. **Agent does the thinking.** CLI fetches data. Agent enriches.
-5. **Tool-agnostic.** Works with any tool that reads files.
+5. **Health before trust.** A successful command run does not automatically mean the workspace matches the current Brief schema.
+6. **Tool-agnostic.** Works with any tool that reads files.
 
 ## Spec
 

--- a/src/__tests__/fetch-guidance.test.ts
+++ b/src/__tests__/fetch-guidance.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+const CLI = join(process.cwd(), "dist/index.js");
+
+function makeTestDir(name: string): string {
+  const dir = `/tmp/brief-fetch-${name}-${Date.now()}`;
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function fillInterview(dir: string): void {
+  const file = join(dir, ".brief/PRIORITIES-HUMAN.md");
+  writeFileSync(file, "# Human Priorities\n\nLast reviewed: 2026-04-08\nReviewer: test\n\n## Product Priorities\n- P0: Test\n");
+}
+
+describe("brief fetch/check guidance", () => {
+  it("reports missing health state before fetch", () => {
+    const dir = makeTestDir("missing");
+    try {
+      try {
+        execSync(`node ${CLI} fetch`, { cwd: dir, encoding: "utf-8" });
+        expect.fail("fetch should fail without .brief/");
+      } catch (e: any) {
+        const output = `${e.stdout || ""}${e.stderr || ""}`;
+        expect(e.status).toBe(3);
+        expect(output).toContain("health: missing");
+        expect(output).toContain("brief init --template startup");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses convention-first next steps for healthy schema fetch", () => {
+    const dir = makeTestDir("healthy");
+    try {
+      execSync(`node ${CLI} init --template startup`, { cwd: dir });
+      fillInterview(dir);
+      const output = execSync(`node ${CLI} fetch`, { cwd: dir, encoding: "utf-8" });
+      expect(output).toContain("brief check --enrichment");
+      expect(output).toContain("rules/BUILD.md + .brief/raw/");
+      expect(output).not.toContain("brief build");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns clearly when fetch runs in legacy context mode", () => {
+    const dir = makeTestDir("legacy");
+    try {
+      const briefDir = join(dir, ".brief");
+      mkdirSync(join(briefDir, "state"), { recursive: true });
+      mkdirSync(join(briefDir, "people"), { recursive: true });
+      writeFileSync(join(briefDir, "priorities.md"), "# Priorities\n");
+      writeFileSync(join(briefDir, "priorities-raw.md"), "# Raw\n");
+      writeFileSync(join(briefDir, "decisions.md"), "# Decisions\n");
+      writeFileSync(join(briefDir, "team.md"), "# Team\n");
+      writeFileSync(join(briefDir, "overrides.md"), "# Overrides\n");
+      writeFileSync(join(briefDir, "agent-log.md"), "# Agent Log\n");
+      writeFileSync(join(briefDir, ".hash"), "");
+      writeFileSync(join(briefDir, ".sources"), "");
+
+      const output = execSync(`node ${CLI} fetch`, { cwd: dir, encoding: "utf-8" });
+      expect(output).toContain("health: legacy-schema");
+      expect(output).toContain("legacy context mode");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("gives convention-first stale guidance for enrichment checks", () => {
+    const dir = makeTestDir("stale");
+    try {
+      execSync(`node ${CLI} init --template startup`, { cwd: dir });
+      fillInterview(dir);
+      const briefDir = join(dir, ".brief");
+      const prioritiesFile = join(briefDir, "priorities.md");
+      const rawFile = join(briefDir, "priorities-raw.md");
+      utimesSync(prioritiesFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
+      utimesSync(rawFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+
+      try {
+        execSync(`node ${CLI} check --enrichment`, { cwd: dir, encoding: "utf-8" });
+        expect.fail("check --enrichment should report stale");
+      } catch (e: any) {
+        const output = `${e.stdout || ""}${e.stderr || ""}`;
+        expect(e.status).toBe(5);
+        expect(output).toContain("rules/BUILD.md + .brief/raw/");
+        expect(output).toContain("update .brief/priorities.md yourself");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getBriefDir } from "../store/paths.js";
 import { computeHash, readStoredHash, writeHash, hasUrgent } from "../store/hash.js";
-import { assessBriefHealth, exitCodeForHealth } from "../store/health.js";
+import { assessBriefHealth, exitCodeForHealth, formatHealthReport } from "../store/health.js";
 
 interface CheckOptions {
   enrichment?: boolean;
@@ -10,16 +10,24 @@ interface CheckOptions {
   json?: boolean;
 }
 
-function printHealth(options: CheckOptions, health = assessBriefHealth()): never {
+function outputHealth(options: CheckOptions, lines: string[], exitCode: number): never {
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ lines }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+  process.exit(exitCode);
+}
+
+function printHealth(options: CheckOptions, nextSteps: string[] = []): never {
+  const health = assessBriefHealth();
   if (options.json) {
     process.stdout.write(`${JSON.stringify(health, null, 2)}\n`);
-  } else {
-    process.stdout.write(`health: ${health.state}\n`);
-    for (const reason of health.reasons) {
-      process.stdout.write(`- ${reason}\n`);
-    }
+    process.exit(exitCodeForHealth(health.state));
   }
-  process.exit(exitCodeForHealth(health.state));
+
+  const lines = [...formatHealthReport(health), ...nextSteps.map((step) => `- ${step}`)];
+  outputHealth(options, lines, exitCodeForHealth(health.state));
 }
 
 export async function checkCommand(options: CheckOptions): Promise<void> {
@@ -27,11 +35,45 @@ export async function checkCommand(options: CheckOptions): Promise<void> {
   const health = assessBriefHealth();
 
   if (options.health) {
-    printHealth(options, health);
+    const nextSteps: string[] = [];
+    if (health.state === "missing") {
+      nextSteps.push("Run 'brief init --template startup'.");
+    }
+    if (health.state === "legacy-schema") {
+      nextSteps.push("Legacy context can still be fetched, but do not treat this as full modern Brief steering.");
+    }
+    if (health.state === "misconfigured") {
+      nextSteps.push("Fix the missing paths before trusting Brief.");
+    }
+    if (health.state === "stale") {
+      nextSteps.push("Read .brief/rules/BUILD.md + .brief/raw/ and update .brief/priorities.md yourself.");
+    }
+    const lines = [...formatHealthReport(health), ...nextSteps.map((step) => `- ${step}`)];
+    outputHealth(options, lines, exitCodeForHealth(health.state));
   }
 
-  if (health.state === "missing" || health.state === "legacy-schema" || health.state === "misconfigured") {
-    printHealth(options, health);
+  if (health.state === "missing") {
+    outputHealth(options, [...formatHealthReport(health), "- Run 'brief init --template startup'."], exitCodeForHealth(health.state));
+  }
+
+  if (health.state === "legacy-schema") {
+    outputHealth(
+      options,
+      [
+        ...formatHealthReport(health),
+        "- Legacy context is available, but current-schema rules are missing.",
+        "- Do not treat this as full modern Brief steering.",
+      ],
+      exitCodeForHealth(health.state)
+    );
+  }
+
+  if (health.state === "misconfigured") {
+    outputHealth(
+      options,
+      [...formatHealthReport(health), "- Fix the missing paths before trusting Brief."],
+      exitCodeForHealth(health.state)
+    );
   }
 
   if (!existsSync(briefDir)) {
@@ -41,7 +83,9 @@ export async function checkCommand(options: CheckOptions): Promise<void> {
 
   if (options.enrichment) {
     if (health.state === "stale") {
-      process.stdout.write(`stale: ${health.reasons.join(" ")}\n`);
+      process.stdout.write(
+        `stale: ${health.reasons.join(" ")} Read .brief/rules/BUILD.md + .brief/raw/ and update .brief/priorities.md yourself.\n`
+      );
       process.exit(5);
     }
 

--- a/src/cli/fetch.ts
+++ b/src/cli/fetch.ts
@@ -5,14 +5,48 @@ import { promisify } from "node:util";
 import chalk from "chalk";
 import { getBriefDir } from "../store/paths.js";
 import { loadConfig } from "../store/config.js";
+import { assessBriefHealth, formatHealthReport } from "../store/health.js";
 
 const execAsync = promisify(exec);
 
+function printHealthBanner(lines: string[], color: "yellow" | "red" = "yellow"): void {
+  const tint = color === "red" ? chalk.red : chalk.yellow;
+  console.log(tint(`  ${lines[0]}`));
+  for (const line of lines.slice(1)) {
+    console.log(tint(`  ${line}`));
+  }
+  console.log("");
+}
+
+function printNextSteps(): void {
+  console.log(chalk.dim("  Next: run 'brief check --enrichment'."));
+  console.log(chalk.dim("  If it reports stale, read .brief/rules/BUILD.md + .brief/raw/ and update .brief/priorities.md yourself.\n"));
+}
+
 export async function fetchCommand(): Promise<void> {
   const briefDir = getBriefDir();
+  const health = assessBriefHealth();
+
   if (!existsSync(briefDir)) {
-    console.log(chalk.red("  No .brief/ directory found. Run 'brief init' first.\n"));
+    printHealthBanner([...formatHealthReport(health), "- Run 'brief init --template startup' first."], "red");
     process.exit(3);
+  }
+
+  if (health.state === "legacy-schema") {
+    printHealthBanner([
+      ...formatHealthReport(health),
+      "- Continuing in legacy context mode. Do not treat this as full modern Brief steering.",
+    ]);
+  } else if (health.state === "misconfigured") {
+    printHealthBanner([
+      ...formatHealthReport(health),
+      "- Continuing with best-effort fetch, but the current schema is broken.",
+    ]);
+  } else if (health.state === "stale") {
+    printHealthBanner([
+      ...formatHealthReport(health),
+      "- Continuing fetch. You will still need to rebuild priorities from rules + raw afterward.",
+    ]);
   }
 
   const rawDir = join(briefDir, "raw");
@@ -24,7 +58,6 @@ export async function fetchCommand(): Promise<void> {
 
   console.log(chalk.dim("  Fetching data...\n"));
 
-  // Fetch from brief.toml sources
   for (const source of config.sources) {
     if (source.type === "command" && source.command) {
       try {
@@ -95,9 +128,8 @@ export async function fetchCommand(): Promise<void> {
     }
   }
 
-  // Run post_sync hook if configured
   if (config.hooks?.post_sync) {
-    console.log(chalk.dim(`\n  Running post-fetch hook...`));
+    console.log(chalk.dim("\n  Running post-fetch hook..."));
     try {
       const { stdout } = await execAsync(config.hooks.post_sync, {
         timeout: 60000,
@@ -110,5 +142,20 @@ export async function fetchCommand(): Promise<void> {
   }
 
   console.log(chalk.green(`\n  ✓ Fetched ${fetched} source${fetched !== 1 ? "s" : ""}${failed > 0 ? chalk.yellow(`, ${failed} failed`) : ""}.\n`));
-  console.log(chalk.dim("  Next: run 'brief build' to combine data into PRIORITIES.md\n"));
+
+  const postFetchHealth = assessBriefHealth();
+  if (postFetchHealth.state === "legacy-schema") {
+    console.log(chalk.yellow("  Next: use the fetched files as context only. This workspace is still legacy-shaped.\n"));
+    return;
+  }
+
+  if (postFetchHealth.state === "misconfigured") {
+    printHealthBanner([
+      ...formatHealthReport(postFetchHealth),
+      "- Fix the schema before trusting Brief as a steering layer.",
+    ]);
+    return;
+  }
+
+  printNextSteps();
 }

--- a/src/store/health.ts
+++ b/src/store/health.ts
@@ -134,6 +134,10 @@ export function assessBriefHealth(base: string = process.cwd()): BriefHealthRepo
   };
 }
 
+export function formatHealthReport(report: BriefHealthReport): string[] {
+  return [`health: ${report.state}`, ...report.reasons.map((reason) => `- ${reason}`)];
+}
+
 export function exitCodeForHealth(state: BriefHealthState): number {
   switch (state) {
     case "healthy-current-schema":


### PR DESCRIPTION
## Summary
- make `brief fetch` health-aware so missing, legacy, misconfigured, and stale workspaces are surfaced explicitly instead of looking silently successful
- make `brief check --enrichment` return convention-first guidance (`rules/BUILD.md + raw/ -> update priorities.md`) and remove stale `brief build` messaging
- add fetch/check guidance tests for missing, healthy, legacy, and stale cases

## Testing
- npm test

Closes #53
