### PR TITLE
refactor: unify startup schema manifest

### DIFF
--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { assessBriefHealth } from "../store/health.js";
-import { CURRENT_SCHEMA, FILES } from "../store/paths.js";
+import { getStartupSchemaManifest, FILES } from "../store/paths.js";
 
 function makeTestDir(name: string): string {
   const dir = `/tmp/brief-health-${name}-${Date.now()}`;
@@ -10,22 +10,21 @@ function makeTestDir(name: string): string {
   return dir;
 }
 
-function createCurrentSchema(dir: string, options: { stale?: boolean; unreviewedHuman?: boolean } = {}): void {
+function createCurrentSchema(dir: string, options: { stale?: boolean } = {}): void {
   const briefDir = join(dir, ".brief");
-  mkdirSync(briefDir, { recursive: true });
+  const manifest = getStartupSchemaManifest();
 
-  for (const relativeDir of CURRENT_SCHEMA.requiredDirs) {
+  mkdirSync(briefDir, { recursive: true });
+  for (const relativeDir of manifest.requiredDirs) {
     mkdirSync(join(briefDir, relativeDir), { recursive: true });
   }
 
-  for (const relativeFile of CURRENT_SCHEMA.requiredFiles) {
+  for (const relativeFile of manifest.requiredFiles) {
     const fullPath = join(briefDir, relativeFile);
     mkdirSync(join(fullPath, ".."), { recursive: true });
     let content = "ok\n";
     if (relativeFile === FILES.humanPriorities) {
-      content = options.unreviewedHuman
-        ? "# Human Priorities\n\nLast reviewed: (not yet)\n"
-        : "# Human Priorities\n\nLast reviewed: 2026-04-08\nReviewer: test\n";
+      content = "# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n";
     }
     writeFileSync(fullPath, content);
   }
@@ -34,6 +33,7 @@ function createCurrentSchema(dir: string, options: { stale?: boolean; unreviewed
   const rawFile = join(briefDir, FILES.prioritiesRaw);
   utimesSync(rawFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
   utimesSync(prioritiesFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+
   if (options.stale) {
     utimesSync(prioritiesFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
     utimesSync(rawFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -1,44 +1,56 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { existsSync, rmSync, readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { execSync } from "node:child_process";
-
-const TEST_DIR = "/tmp/brief-test-init";
-const CLI = join(process.cwd(), "dist/index.js");
+import { tmpdir } from "node:os";
+import { initCommand } from "../cli/init.js";
+import { assessBriefHealth } from "../store/health.js";
+import { FILES, getBriefDir, getStartupSchemaManifest } from "../store/paths.js";
 
 describe("brief init", () => {
+  const originalCwd = process.cwd();
+  let testDir: string;
+
   beforeEach(() => {
-    rmSync(TEST_DIR, { recursive: true, force: true });
-    execSync(`mkdir -p ${TEST_DIR}`);
+    testDir = mkdtempSync(join(tmpdir(), "brief-init-"));
+    process.chdir(testDir);
   });
 
   afterEach(() => {
-    rmSync(TEST_DIR, { recursive: true, force: true });
+    process.chdir(originalCwd);
+    rmSync(testDir, { recursive: true, force: true });
   });
 
-  it("creates .brief/ directory structure", () => {
-    execSync(`node ${CLI} init`, { cwd: TEST_DIR });
-    expect(existsSync(join(TEST_DIR, ".brief"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/priorities.md"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/decisions.md"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/team.md"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/overrides.md"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/agent-log.md"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/state"))).toBe(true);
-    expect(existsSync(join(TEST_DIR, ".brief/people"))).toBe(true);
+  it("creates every required path from the startup schema manifest", async () => {
+    await initCommand({ template: "startup" });
+
+    const briefDir = getBriefDir(testDir);
+    const manifest = getStartupSchemaManifest();
+
+    for (const relativeDir of manifest.requiredDirs) {
+      expect(existsSync(join(briefDir, relativeDir))).toBe(true);
+    }
+
+    for (const relativeFile of manifest.requiredFiles) {
+      expect(existsSync(join(briefDir, relativeFile))).toBe(true);
+    }
   });
 
-  it("--template startup adds example content", () => {
-    execSync(`node ${CLI} init --template startup`, { cwd: TEST_DIR });
-    const priorities = readFileSync(join(TEST_DIR, ".brief/priorities.md"), "utf-8");
-    expect(priorities).toContain("## NOW");
-    expect(priorities).toContain("## TODAY");
-    expect(priorities).toContain("brief_version: 1");
+  it("creates a workspace that health detection immediately recognizes as current schema", async () => {
+    await initCommand({ template: "startup" });
+
+    const report = assessBriefHealth(testDir);
+    expect(report.state).toBe("healthy-current-schema");
+    expect(report.schema).toBe("current");
   });
 
-  it("refuses to init if .brief/ already exists", () => {
-    execSync(`node ${CLI} init`, { cwd: TEST_DIR });
-    const output = execSync(`node ${CLI} init`, { cwd: TEST_DIR, encoding: "utf-8" });
-    expect(output).toContain("already exists");
+  it("seeds the expected startup artifacts", async () => {
+    await initCommand({ template: "startup" });
+
+    const briefDir = getBriefDir(testDir);
+    const humanPriorities = readFileSync(join(briefDir, FILES.humanPriorities), "utf-8");
+    const sources = readFileSync(join(briefDir, FILES.sources), "utf-8");
+
+    expect(humanPriorities).toContain("# Human Priorities");
+    expect(sources.trim()).toBe("[]");
   });
 });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,124 +1,101 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import chalk from "chalk";
-import { getBriefDir, FILES, DIRS } from "../store/paths.js";
-import { makeFrontmatter } from "../store/frontmatter.js";
+import { getBriefDir, getStartupSchemaManifest, DIRS, FILES } from "../store/paths.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getTemplateDir(): string {
+  const distPath = join(__dirname, "..", "templates");
+  if (existsSync(distPath)) return distPath;
+  return join(__dirname, "..", "..", "src", "templates");
+}
+
+function buildSeedContent(relativePath: string, useTemplate: boolean, briefDir: string): string {
+  switch (relativePath) {
+    case FILES.priorities:
+      return useTemplate
+        ? `# Priorities\n\n## Now\n- [ ] Example urgent item\n\n## Next\n- [ ] Example next item\n\n## Waiting\n- [ ] Example blocked item\n`
+        : `# Priorities\n\n## Now\n\n## Next\n\n## Waiting\n`;
+    case FILES.prioritiesRaw:
+      return "# Raw Inputs\n\n<!-- fetched inputs go here -->\n";
+    case FILES.decisions:
+      return "# Decisions\n\n";
+    case FILES.decisionsRaw:
+      return "# Decision Inputs\n\n";
+    case FILES.team:
+      return useTemplate
+        ? `# Team\n\n## Roles\n- Founder: you\n- Agent: Brief-compatible AI\n`
+        : "# Team\n\n";
+    case FILES.overrides:
+      return "# Overrides\n\n";
+    case FILES.agentLog:
+      return "# Agent Log\n\n";
+    case FILES.hash:
+      return "";
+    case FILES.sources:
+      return existsSync(join(briefDir, FILES.sources)) ? readFileSync(join(briefDir, FILES.sources), "utf-8") : "[]\n";
+    case FILES.humanPriorities:
+      return useTemplate
+        ? `# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n\n## Product Priorities\n- P0: \n- P1: \n- P2: \n\n## Constraints\n- \n\n## This Week\n- \n`
+        : "# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n";
+    default:
+      throw new Error(`No seed content defined for ${relativePath}`);
+  }
+}
 
 interface InitOptions {
   template?: string;
-  detect?: boolean;
 }
-
-const STARTUP_PRIORITIES = `# Priorities
-
-## NOW
-- (Add your top priority items here)
-
-## TODAY
-- (Add items to fit in today)
-
-## IGNORED (0 items)
-`;
-
-const STARTUP_DECISIONS = `# Recent Decisions
-
-## ${new Date().toISOString().split("T")[0]}
-- (Log decisions from meetings and discussions here)
-`;
-
-const STARTUP_TEAM = `# Team
-
-| Name | Role | Focus |
-|------|------|-------|
-| (Add team members) | | |
-`;
-
-const STARTUP_OVERRIDES = `# Overrides
-# This is the only file you edit directly. The CLI reads it during sync.
-
-## Add
-# - Item to inject into priorities
-#   Reason: why
-#   Expires: YYYY-MM-DD
-
-## Remove
-# - issue:repo#N  # reason
-
-## Boost
-# - pr:repo#N
-#   Priority: now
-`;
 
 export async function initCommand(options: InitOptions): Promise<void> {
   const briefDir = getBriefDir();
+  const useTemplate = options.template === "startup";
+  const manifest = getStartupSchemaManifest();
 
   if (existsSync(briefDir)) {
-    console.log(chalk.yellow("  .brief/ already exists. Use brief validate to check integrity.\n"));
+    console.log("Brief already exists here.");
+    console.log(`Path: ${briefDir}`);
+    console.log("Run `brief check --health` to inspect the current workspace state.");
     return;
   }
 
-  // Create directories
   mkdirSync(briefDir, { recursive: true });
-  mkdirSync(join(briefDir, DIRS.state), { recursive: true });
-  mkdirSync(join(briefDir, DIRS.people), { recursive: true });
-  mkdirSync(join(briefDir, DIRS.rules), { recursive: true });
-  mkdirSync(join(briefDir, DIRS.raw), { recursive: true });
-
-  // Copy rules templates — check both dist and src paths
-  let templatesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "templates", "rules");
-  if (!existsSync(templatesDir)) {
-    // Fallback to src/templates when running from dist/
-    templatesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "templates", "rules");
+  for (const relativeDir of manifest.requiredDirs) {
+    mkdirSync(join(briefDir, relativeDir), { recursive: true });
   }
-  if (existsSync(templatesDir)) {
-    for (const file of readdirSync(templatesDir)) {
-      const src = join(templatesDir, file);
-      const dest = join(briefDir, DIRS.rules, file);
-      if (!existsSync(dest)) {
-        writeFileSync(dest, readFileSync(src, "utf-8"));
-      }
+
+  const templateDir = getTemplateDir();
+  const rulesSrc = join(templateDir, DIRS.rules);
+  const availableRuleFiles = existsSync(rulesSrc)
+    ? readdirSync(rulesSrc).filter((file) => file.endsWith(".md"))
+    : [];
+
+  for (const ruleFile of manifest.ruleTemplateFiles) {
+    const src = join(rulesSrc, ruleFile);
+    const dest = join(briefDir, DIRS.rules, ruleFile);
+    if (availableRuleFiles.includes(ruleFile)) {
+      writeFileSync(dest, readFileSync(src, "utf-8"));
     }
   }
 
-  const fm = makeFrontmatter();
-  const useTemplate = options.template === "startup";
-
-  // Create files
-  writeFileSync(join(briefDir, FILES.priorities), fm + (useTemplate ? STARTUP_PRIORITIES : "# Priorities\n"));
-  writeFileSync(join(briefDir, FILES.prioritiesRaw), fm + "# Priorities (Raw)\n\nThis file is auto-generated by `brief sync`. Do not edit — edit priorities.md instead.\n");
-  writeFileSync(join(briefDir, FILES.decisions), fm + (useTemplate ? STARTUP_DECISIONS : "# Recent Decisions\n"));
-  writeFileSync(join(briefDir, FILES.team), fm + (useTemplate ? STARTUP_TEAM : "# Team\n"));
-  writeFileSync(join(briefDir, FILES.overrides), useTemplate ? STARTUP_OVERRIDES : "# Overrides\n");
-  writeFileSync(join(briefDir, FILES.agentLog), "# Agent Actions\n");
-  writeFileSync(join(briefDir, FILES.hash), "");
-  writeFileSync(join(briefDir, FILES.sources), "");
-
-  // Create blank PRIORITIES-HUMAN.md template
-  const humanPriFile = join(briefDir, FILES.humanPriorities);
-  if (!existsSync(humanPriFile)) {
-    writeFileSync(humanPriFile, `# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: (not yet)\n\n## Product Priorities\n- P0: (run the interview — see rules/INTERVIEW.md)\n\n## Active Deals\n- (none yet)\n\n## Do NOT Work On\n- (none yet)\n\n## Blockers Needing Human Decision\n- (none yet)\n`);
+  for (const relativeFile of manifest.seedFiles) {
+    const fullPath = join(briefDir, relativeFile);
+    writeFileSync(fullPath, buildSeedContent(relativeFile, useTemplate, briefDir));
   }
 
-  console.log(chalk.green("  ✓ .brief/ initialized.\n"));
-  console.log(chalk.yellow("  ⚠ Next: run the priority interview before fetching data."));
-  console.log(chalk.dim("  Read .brief/rules/INTERVIEW.md and update .brief/PRIORITIES-HUMAN.md"));
-  console.log(chalk.dim("  Then: read .brief/rules/SETUP.md to configure data sources.\n"));
+  console.log(`Initialized Brief in ${briefDir}`);
 
-  // Detect existing conventions
-  if (options.detect !== false) {
-    const cwd = process.cwd();
-    const conventions = [
-      { file: "CLAUDE.md", tool: "Claude Code" },
-      { file: "AGENTS.md", tool: "AI agents" },
-      { file: ".cursorrules", tool: "Cursor" },
-      { file: ".codex/instructions", tool: "Codex" },
-    ];
-
-    for (const { file, tool } of conventions) {
-      if (existsSync(join(cwd, file))) {
-        console.log(chalk.dim(`  Found ${file} (${tool}). Run 'brief snippet ${tool.toLowerCase().split(" ")[0]}' to get integration code.\n`));
-      }
-    }
+  if (useTemplate) {
+    console.log("\nStartup template created:");
+    console.log("- Human priorities interview scaffold");
+    console.log("- Rules directory with build/fetch/interview/morning/evening guides");
+    console.log("- Raw/ state/ people/ directories");
   }
+
+  console.log("\nNext steps:");
+  console.log("1. Fill in .brief/PRIORITIES-HUMAN.md");
+  console.log("2. Configure sources in .brief/.sources");
+  console.log("3. Run `brief check --health`");
+  console.log("4. Run `brief fetch`");
 }

--- a/src/store/health.ts
+++ b/src/store/health.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { CURRENT_SCHEMA, FILES, getBriefDir } from "./paths.js";
+import { FILES, getBriefDir, getStartupSchemaManifest } from "./paths.js";
 
 export type BriefHealthState =
   | "healthy-current-schema"
@@ -31,8 +31,6 @@ function staleReasons(briefDir: string): string[] {
   const reasons: string[] = [];
   const prioritiesFile = join(briefDir, FILES.priorities);
   const rawFile = join(briefDir, FILES.prioritiesRaw);
-  const humanFile = join(briefDir, FILES.humanPriorities);
-
   if (!existsSync(rawFile)) {
     reasons.push(`Missing ${FILES.prioritiesRaw}.`);
   }
@@ -49,19 +47,13 @@ function staleReasons(briefDir: string): string[] {
     }
   }
 
-  if (existsSync(humanFile)) {
-    const content = readFileSync(humanFile, "utf-8");
-    if (content.includes("Last reviewed: (not yet)")) {
-      reasons.push(`${FILES.humanPriorities} has not been reviewed yet.`);
-    }
-  }
-
   return reasons;
 }
 
 export function assessBriefHealth(base: string = process.cwd()): BriefHealthReport {
   const briefDir = getBriefDir(base);
   const checkedAt = new Date().toISOString();
+  const manifest = getStartupSchemaManifest();
 
   if (!existsSync(briefDir)) {
     return {
@@ -75,9 +67,8 @@ export function assessBriefHealth(base: string = process.cwd()): BriefHealthRepo
     };
   }
 
-  const requiredPaths = [...CURRENT_SCHEMA.requiredDirs, ...CURRENT_SCHEMA.requiredFiles];
-  const present = existingPaths(briefDir, requiredPaths);
-  const missing = missingPaths(briefDir, requiredPaths);
+  const present = existingPaths(briefDir, manifest.requiredPaths);
+  const missing = missingPaths(briefDir, manifest.requiredPaths);
 
   if (missing.length === 0) {
     const stale = staleReasons(briefDir);
@@ -104,8 +95,8 @@ export function assessBriefHealth(base: string = process.cwd()): BriefHealthRepo
     };
   }
 
-  const legacyPresent = existingPaths(briefDir, CURRENT_SCHEMA.legacySignals);
-  const missingCurrentMarkers = missingPaths(briefDir, CURRENT_SCHEMA.legacyMissingMarkers);
+  const legacyPresent = existingPaths(briefDir, manifest.legacySignals);
+  const missingCurrentMarkers = missingPaths(briefDir, manifest.legacyMissingMarkers);
   const looksLegacy = legacyPresent.length >= 3 && missingCurrentMarkers.length > 0;
 
   if (looksLegacy) {

--- a/src/store/paths.ts
+++ b/src/store/paths.ts
@@ -1,4 +1,8 @@
-import { join } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function getBriefDir(base: string = process.cwd()): string {
   return join(base, ".brief");
@@ -24,30 +28,58 @@ export const DIRS = {
   raw: "raw",
 } as const;
 
-export const RULE_TEMPLATES = [
-  "BUILD.md",
-  "EVENING.md",
-  "FETCH.md",
-  "INTERVIEW.md",
-  "MORNING.md",
-  "SETUP.md",
-] as const;
+export interface BriefSchemaManifest {
+  template: "startup";
+  requiredDirs: string[];
+  seedFiles: string[];
+  ruleTemplateFiles: string[];
+  requiredFiles: string[];
+  requiredPaths: string[];
+  currentSchemaMarkers: string[];
+  legacySignals: string[];
+  legacyMissingMarkers: string[];
+}
 
-export const CURRENT_SCHEMA = {
-  requiredFiles: [
+function getRulesTemplateDir(): string {
+  const distPath = join(__dirname, "..", "templates", DIRS.rules);
+  if (existsSync(distPath)) return distPath;
+  return join(__dirname, "..", "..", "src", "templates", DIRS.rules);
+}
+
+export function getRuleTemplateFiles(): string[] {
+  const rulesDir = getRulesTemplateDir();
+  if (!existsSync(rulesDir)) return [];
+  return readdirSync(rulesDir)
+    .filter((file) => file.endsWith(".md"))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function getStartupSchemaManifest(): BriefSchemaManifest {
+  const requiredDirs = [DIRS.state, DIRS.people, DIRS.rules, DIRS.raw];
+  const seedFiles = [
     FILES.priorities,
     FILES.prioritiesRaw,
     FILES.decisions,
+    FILES.decisionsRaw,
     FILES.team,
     FILES.overrides,
     FILES.agentLog,
     FILES.hash,
     FILES.sources,
     FILES.humanPriorities,
-    ...RULE_TEMPLATES.map((rule) => join(DIRS.rules, rule)),
-  ],
-  requiredDirs: [DIRS.state, DIRS.people, DIRS.rules, DIRS.raw],
-  legacySignals: [
+  ];
+  const ruleTemplateFiles = getRuleTemplateFiles();
+  const requiredFiles = [
+    ...seedFiles,
+    ...ruleTemplateFiles.map((ruleFile) => join(DIRS.rules, ruleFile)),
+  ];
+  const currentSchemaMarkers = [
+    FILES.humanPriorities,
+    join(DIRS.rules, "BUILD.md"),
+    join(DIRS.rules, "INTERVIEW.md"),
+    DIRS.raw,
+  ];
+  const legacySignals = [
     FILES.priorities,
     FILES.prioritiesRaw,
     FILES.decisions,
@@ -56,6 +88,17 @@ export const CURRENT_SCHEMA = {
     FILES.agentLog,
     DIRS.state,
     DIRS.people,
-  ],
-  legacyMissingMarkers: [FILES.humanPriorities, join(DIRS.rules, "BUILD.md"), join(DIRS.rules, "INTERVIEW.md"), DIRS.raw],
-} as const;
+  ];
+
+  return {
+    template: "startup",
+    requiredDirs,
+    seedFiles,
+    ruleTemplateFiles,
+    requiredFiles,
+    requiredPaths: [...requiredDirs, ...requiredFiles],
+    currentSchemaMarkers,
+    legacySignals,
+    legacyMissingMarkers: currentSchemaMarkers,
+  };
+}


### PR DESCRIPTION
## Summary
- make the startup schema manifest the shared source of truth for init and health detection
- derive rule-template requirements from the actual template directory instead of scattered assumptions
- add tests that prove `brief init --template startup` creates a workspace health detection recognizes as current schema

## Testing
- npm test

Closes #58
