### PR TITLE
feat: add brief migrate command

### DIFF
--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CLI = join(process.cwd(), "dist/index.js");
+
+function makeTestDir(name: string): string {
+  const dir = `/tmp/brief-migrate-${name}-${Date.now()}`;
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createLegacyWorkspace(dir: string): void {
+  const briefDir = join(dir, ".brief");
+  mkdirSync(join(briefDir, "state"), { recursive: true });
+  mkdirSync(join(briefDir, "people"), { recursive: true });
+  writeFileSync(join(briefDir, "priorities.md"), "# Priorities\n");
+  writeFileSync(join(briefDir, "priorities-raw.md"), "# Raw Inputs\n");
+  writeFileSync(join(briefDir, "decisions.md"), "# Decisions\n");
+  writeFileSync(join(briefDir, "team.md"), "# Team\n");
+  writeFileSync(join(briefDir, "overrides.md"), "# Overrides\n");
+  writeFileSync(join(briefDir, "agent-log.md"), "# Agent Log\n");
+}
+
+describe("brief migrate", () => {
+  it("shows a deterministic dry-run plan for legacy workspaces", () => {
+    const dir = makeTestDir("dry-run");
+    try {
+      createLegacyWorkspace(dir);
+      const output = execSync(`node ${CLI} migrate --dry-run`, { cwd: dir, encoding: "utf-8" });
+      expect(output).toContain("migration: legacy-schema -> healthy-current-schema");
+      expect(output).toContain("PRIORITIES-HUMAN.md");
+      expect(output).toContain("rules/BUILD.md");
+      expect(existsSync(join(dir, ".brief", "PRIORITIES-HUMAN.md"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies migration and upgrades legacy workspaces to current schema", () => {
+    const dir = makeTestDir("apply");
+    try {
+      createLegacyWorkspace(dir);
+      const output = execSync(`node ${CLI} migrate`, { cwd: dir, encoding: "utf-8" });
+      expect(output).toContain("post-migration health: healthy-current-schema");
+      expect(existsSync(join(dir, ".brief", "PRIORITIES-HUMAN.md"))).toBe(true);
+      expect(existsSync(join(dir, ".brief", "raw"))).toBe(true);
+
+      const health = execSync(`node ${CLI} check --health`, { cwd: dir, encoding: "utf-8" });
+      expect(health).toContain("health: healthy-current-schema");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent after a workspace has been migrated", () => {
+    const dir = makeTestDir("idempotent");
+    try {
+      createLegacyWorkspace(dir);
+      execSync(`node ${CLI} migrate`, { cwd: dir, encoding: "utf-8" });
+      const output = execSync(`node ${CLI} migrate`, { cwd: dir, encoding: "utf-8" });
+      expect(output).toContain("migration: nothing to do (healthy-current-schema)");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,48 +1,6 @@
-import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { getBriefDir, getStartupSchemaManifest, DIRS, FILES } from "../store/paths.js";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function getTemplateDir(): string {
-  const distPath = join(__dirname, "..", "templates");
-  if (existsSync(distPath)) return distPath;
-  return join(__dirname, "..", "..", "src", "templates");
-}
-
-function buildSeedContent(relativePath: string, useTemplate: boolean, briefDir: string): string {
-  switch (relativePath) {
-    case FILES.priorities:
-      return useTemplate
-        ? `# Priorities\n\n## Now\n- [ ] Example urgent item\n\n## Next\n- [ ] Example next item\n\n## Waiting\n- [ ] Example blocked item\n`
-        : `# Priorities\n\n## Now\n\n## Next\n\n## Waiting\n`;
-    case FILES.prioritiesRaw:
-      return "# Raw Inputs\n\n<!-- fetched inputs go here -->\n";
-    case FILES.decisions:
-      return "# Decisions\n\n";
-    case FILES.decisionsRaw:
-      return "# Decision Inputs\n\n";
-    case FILES.team:
-      return useTemplate
-        ? `# Team\n\n## Roles\n- Founder: you\n- Agent: Brief-compatible AI\n`
-        : "# Team\n\n";
-    case FILES.overrides:
-      return "# Overrides\n\n";
-    case FILES.agentLog:
-      return "# Agent Log\n\n";
-    case FILES.hash:
-      return "";
-    case FILES.sources:
-      return existsSync(join(briefDir, FILES.sources)) ? readFileSync(join(briefDir, FILES.sources), "utf-8") : "[]\n";
-    case FILES.humanPriorities:
-      return useTemplate
-        ? `# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n\n## Product Priorities\n- P0: \n- P1: \n- P2: \n\n## Constraints\n- \n\n## This Week\n- \n`
-        : "# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n";
-    default:
-      throw new Error(`No seed content defined for ${relativePath}`);
-  }
-}
+import { existsSync, mkdirSync } from "node:fs";
+import { getBriefDir, getStartupSchemaManifest } from "../store/paths.js";
+import { ensureManifestScaffold } from "../store/scaffold.js";
 
 interface InitOptions {
   template?: string;
@@ -61,28 +19,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   }
 
   mkdirSync(briefDir, { recursive: true });
-  for (const relativeDir of manifest.requiredDirs) {
-    mkdirSync(join(briefDir, relativeDir), { recursive: true });
-  }
-
-  const templateDir = getTemplateDir();
-  const rulesSrc = join(templateDir, DIRS.rules);
-  const availableRuleFiles = existsSync(rulesSrc)
-    ? readdirSync(rulesSrc).filter((file) => file.endsWith(".md"))
-    : [];
-
-  for (const ruleFile of manifest.ruleTemplateFiles) {
-    const src = join(rulesSrc, ruleFile);
-    const dest = join(briefDir, DIRS.rules, ruleFile);
-    if (availableRuleFiles.includes(ruleFile)) {
-      writeFileSync(dest, readFileSync(src, "utf-8"));
-    }
-  }
-
-  for (const relativeFile of manifest.seedFiles) {
-    const fullPath = join(briefDir, relativeFile);
-    writeFileSync(fullPath, buildSeedContent(relativeFile, useTemplate, briefDir));
-  }
+  ensureManifestScaffold(briefDir, manifest, useTemplate ? "startup" : "minimal");
 
   console.log(`Initialized Brief in ${briefDir}`);
 

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,128 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { assessBriefHealth, formatHealthReport, exitCodeForHealth } from "../store/health.js";
+import { getBriefDir, getStartupSchemaManifest } from "../store/paths.js";
+import { ensureManifestScaffold } from "../store/scaffold.js";
+
+interface MigrateOptions {
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+interface MigrationPlan {
+  from: string;
+  to: string;
+  briefDir: string;
+  detectedLegacySignals: string[];
+  createDirs: string[];
+  createFiles: string[];
+  untouchedFiles: string[];
+  postMigrationState?: string;
+  manualFollowUp: string[];
+}
+
+function buildMigrationPlan(base: string = process.cwd()): MigrationPlan {
+  const briefDir = getBriefDir(base);
+  const manifest = getStartupSchemaManifest();
+  const detectedLegacySignals = manifest.legacySignals.filter((relativePath) => existsSync(join(briefDir, relativePath)));
+  const createDirs = manifest.requiredDirs.filter((relativePath) => !existsSync(join(briefDir, relativePath)));
+  const createFiles = [
+    ...manifest.ruleTemplateFiles
+      .map((ruleFile) => join("rules", ruleFile))
+      .filter((relativePath) => !existsSync(join(briefDir, relativePath))),
+    ...manifest.seedFiles.filter((relativePath) => !existsSync(join(briefDir, relativePath))),
+  ];
+  const untouchedFiles = manifest.requiredFiles.filter((relativePath) => existsSync(join(briefDir, relativePath)));
+
+  return {
+    from: "legacy-schema",
+    to: "healthy-current-schema",
+    briefDir,
+    detectedLegacySignals,
+    createDirs,
+    createFiles,
+    untouchedFiles,
+    manualFollowUp: [
+      "Review .brief/PRIORITIES-HUMAN.md and fill in real priorities.",
+      "Run `brief check --health` after migration.",
+      "Run `brief fetch` and then `brief check --enrichment` before trusting priorities.",
+    ],
+  };
+}
+
+function printPlan(plan: MigrationPlan): void {
+  console.log(`migration: ${plan.from} -> ${plan.to}`);
+  console.log(`path: ${plan.briefDir}`);
+
+  console.log("\nDetected legacy signals:");
+  for (const item of plan.detectedLegacySignals) {
+    console.log(`- ${item}`);
+  }
+
+  console.log("\nCreate directories:");
+  if (plan.createDirs.length === 0) {
+    console.log("- (none)");
+  } else {
+    for (const item of plan.createDirs) console.log(`- ${item}`);
+  }
+
+  console.log("\nCreate files:");
+  if (plan.createFiles.length === 0) {
+    console.log("- (none)");
+  } else {
+    for (const item of plan.createFiles) console.log(`- ${item}`);
+  }
+
+  console.log("\nLeave untouched:");
+  if (plan.untouchedFiles.length === 0) {
+    console.log("- (none)");
+  } else {
+    for (const item of plan.untouchedFiles) console.log(`- ${item}`);
+  }
+
+  console.log("\nManual follow-up:");
+  for (const item of plan.manualFollowUp) {
+    console.log(`- ${item}`);
+  }
+
+  if (plan.postMigrationState) {
+    console.log(`\npost-migration health: ${plan.postMigrationState}`);
+  }
+}
+
+export async function migrateCommand(options: MigrateOptions): Promise<void> {
+  const health = assessBriefHealth();
+
+  if (health.state === "missing" || health.state === "misconfigured") {
+    for (const line of formatHealthReport(health)) console.log(line);
+    process.exit(exitCodeForHealth(health.state));
+  }
+
+  if (health.state === "healthy-current-schema" || health.state === "stale") {
+    console.log(`migration: nothing to do (${health.state})`);
+    process.exit(0);
+  }
+
+  const plan = buildMigrationPlan();
+
+  if (options.json) {
+    console.log(JSON.stringify(plan, null, 2));
+    if (options.dryRun) return;
+  }
+
+  if (options.dryRun) {
+    printPlan(plan);
+    return;
+  }
+
+  const manifest = getStartupSchemaManifest();
+  ensureManifestScaffold(plan.briefDir, manifest, "minimal");
+  const postHealth = assessBriefHealth();
+  plan.postMigrationState = postHealth.state;
+  printPlan(plan);
+
+  if (postHealth.state !== "healthy-current-schema") {
+    for (const line of formatHealthReport(postHealth)) console.log(line);
+    process.exit(exitCodeForHealth(postHealth.state));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,27 +7,26 @@ import { Command } from "commander";
 import { initCommand } from "./cli/init.js";
 import { fetchCommand } from "./cli/fetch.js";
 import { checkCommand } from "./cli/check.js";
+import { migrateCommand } from "./cli/migrate.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
 
 const program = new Command();
-
 program
   .name("brief")
-  .description("Team working memory for AI agents and humans.")
+  .description("Team working memory for AI agents and humans")
   .version(pkg.version);
 
 program
   .command("init")
-  .description("Create .brief/ directory with rules templates")
+  .description("Create .brief/ using the startup template")
   .option("--template <name>", "Bootstrap with example content (startup)")
-  .option("--no-detect", "Skip detection of existing CLAUDE.md/AGENTS.md")
   .action(initCommand);
 
 program
   .command("fetch")
-  .description("Fetch data from configured sources into .brief/raw/")
+  .description("Fetch configured sources into .brief/raw/")
   .action(fetchCommand);
 
 program
@@ -37,5 +36,12 @@ program
   .option("--health", "Inspect brief health/schema state")
   .option("--json", "Output health as JSON (use with --health)")
   .action(checkCommand);
+
+program
+  .command("migrate")
+  .description("Upgrade a legacy Brief workspace toward the current startup schema")
+  .option("--dry-run", "Show the migration plan without writing files")
+  .option("--json", "Output the migration plan as JSON")
+  .action(migrateCommand);
 
 program.parse();

--- a/src/store/scaffold.ts
+++ b/src/store/scaffold.ts
@@ -1,0 +1,106 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { BriefSchemaManifest } from "./paths.js";
+import { DIRS, FILES } from "./paths.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export type SeedMode = "startup" | "minimal";
+
+export function getTemplateDir(): string {
+  const distPath = join(__dirname, "..", "templates");
+  if (existsSync(distPath)) return distPath;
+  return join(__dirname, "..", "..", "src", "templates");
+}
+
+export function buildSeedContent(relativePath: string, mode: SeedMode, briefDir: string): string {
+  switch (relativePath) {
+    case FILES.priorities:
+      return mode === "startup"
+        ? `# Priorities\n\n## Now\n- [ ] Example urgent item\n\n## Next\n- [ ] Example next item\n\n## Waiting\n- [ ] Example blocked item\n`
+        : `# Priorities\n\n## Now\n\n## Next\n\n## Waiting\n`;
+    case FILES.prioritiesRaw:
+      return "# Raw Inputs\n\n<!-- fetched inputs go here -->\n";
+    case FILES.decisions:
+      return "# Decisions\n\n";
+    case FILES.decisionsRaw:
+      return "# Decision Inputs\n\n";
+    case FILES.team:
+      return mode === "startup"
+        ? `# Team\n\n## Roles\n- Founder: you\n- Agent: Brief-compatible AI\n`
+        : "# Team\n\n";
+    case FILES.overrides:
+      return "# Overrides\n\n";
+    case FILES.agentLog:
+      return "# Agent Log\n\n";
+    case FILES.hash:
+      return "";
+    case FILES.sources:
+      return existsSync(join(briefDir, FILES.sources)) ? readFileSync(join(briefDir, FILES.sources), "utf-8") : "[]\n";
+    case FILES.humanPriorities:
+      return mode === "startup"
+        ? `# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n\n## Product Priorities\n- P0: \n- P1: \n- P2: \n\n## Constraints\n- \n\n## This Week\n- \n`
+        : "# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n";
+    default:
+      throw new Error(`No seed content defined for ${relativePath}`);
+  }
+}
+
+export function copyRuleTemplates(briefDir: string, manifest: BriefSchemaManifest): string[] {
+  const templateDir = getTemplateDir();
+  const rulesSrc = join(templateDir, DIRS.rules);
+  const availableRuleFiles = existsSync(rulesSrc)
+    ? readdirSync(rulesSrc).filter((file) => file.endsWith(".md"))
+    : [];
+
+  const written: string[] = [];
+  for (const ruleFile of manifest.ruleTemplateFiles) {
+    if (!availableRuleFiles.includes(ruleFile)) continue;
+    const src = join(rulesSrc, ruleFile);
+    const dest = join(briefDir, DIRS.rules, ruleFile);
+    writeFileSync(dest, readFileSync(src, "utf-8"));
+    written.push(join(DIRS.rules, ruleFile));
+  }
+  return written;
+}
+
+export function ensureManifestScaffold(
+  briefDir: string,
+  manifest: BriefSchemaManifest,
+  mode: SeedMode
+): { dirsCreated: string[]; filesCreated: string[] } {
+  const dirsCreated: string[] = [];
+  const filesCreated: string[] = [];
+
+  for (const relativeDir of manifest.requiredDirs) {
+    const fullPath = join(briefDir, relativeDir);
+    if (!existsSync(fullPath)) {
+      mkdirSync(fullPath, { recursive: true });
+      dirsCreated.push(relativeDir);
+    }
+  }
+
+  const templateDir = getTemplateDir();
+  const rulesSrc = join(templateDir, DIRS.rules);
+  const availableRuleFiles = existsSync(rulesSrc)
+    ? readdirSync(rulesSrc).filter((file) => file.endsWith(".md"))
+    : [];
+
+  for (const ruleFile of manifest.ruleTemplateFiles) {
+    const relativePath = join(DIRS.rules, ruleFile);
+    const fullPath = join(briefDir, relativePath);
+    if (existsSync(fullPath) || !availableRuleFiles.includes(ruleFile)) continue;
+    writeFileSync(fullPath, readFileSync(join(rulesSrc, ruleFile), "utf-8"));
+    filesCreated.push(relativePath);
+  }
+
+  for (const relativeFile of manifest.seedFiles) {
+    const fullPath = join(briefDir, relativeFile);
+    if (existsSync(fullPath)) continue;
+    writeFileSync(fullPath, buildSeedContent(relativeFile, mode, briefDir));
+    filesCreated.push(relativeFile);
+  }
+
+  return { dirsCreated, filesCreated };
+}


### PR DESCRIPTION
## Summary
- add `brief migrate --dry-run` and `brief migrate` for legacy-to-current schema upgrades
- add shared scaffold helpers so migrate and init create the same current-schema structure
- add migration tests for dry-run planning, apply mode, and idempotent re-runs

## Testing
- npm test

## Notes
This PR is stacked on #61 because migrate should build on the shared schema manifest instead of duplicating it.

Closes #57
