### PR TITLE
test: add workspace-shape fixture matrix

### DIFF
--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -1,51 +1,20 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import { assessBriefHealth } from "../store/health.js";
-import { getStartupSchemaManifest, FILES } from "../store/paths.js";
-
-function makeTestDir(name: string): string {
-  const dir = `/tmp/brief-health-${name}-${Date.now()}`;
-  mkdirSync(dir, { recursive: true });
-  return dir;
-}
-
-function createCurrentSchema(dir: string, options: { stale?: boolean } = {}): void {
-  const briefDir = join(dir, ".brief");
-  const manifest = getStartupSchemaManifest();
-
-  mkdirSync(briefDir, { recursive: true });
-  for (const relativeDir of manifest.requiredDirs) {
-    mkdirSync(join(briefDir, relativeDir), { recursive: true });
-  }
-
-  for (const relativeFile of manifest.requiredFiles) {
-    const fullPath = join(briefDir, relativeFile);
-    mkdirSync(join(fullPath, ".."), { recursive: true });
-    let content = "ok\n";
-    if (relativeFile === FILES.humanPriorities) {
-      content = "# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n";
-    }
-    writeFileSync(fullPath, content);
-  }
-
-  const prioritiesFile = join(briefDir, FILES.priorities);
-  const rawFile = join(briefDir, FILES.prioritiesRaw);
-  utimesSync(rawFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
-  utimesSync(prioritiesFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
-
-  if (options.stale) {
-    utimesSync(prioritiesFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
-    utimesSync(rawFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
-  }
-}
+import { FILES } from "../store/paths.js";
+import {
+  cleanupDir,
+  createCurrentWorkspace,
+  createLegacyWorkspace,
+  createMisconfiguredWorkspace,
+  makeTestDir,
+} from "./helpers/workspaces.js";
 
 describe("assessBriefHealth", () => {
   const dirs: string[] = [];
 
   afterEach(() => {
     for (const dir of dirs) {
-      rmSync(dir, { recursive: true, force: true });
+      cleanupDir(dir);
     }
     dirs.length = 0;
   });
@@ -53,7 +22,7 @@ describe("assessBriefHealth", () => {
   it("detects healthy current schema", () => {
     const dir = makeTestDir("healthy");
     dirs.push(dir);
-    createCurrentSchema(dir);
+    createCurrentWorkspace(dir);
 
     const report = assessBriefHealth(dir);
     expect(report.state).toBe("healthy-current-schema");
@@ -63,7 +32,7 @@ describe("assessBriefHealth", () => {
   it("detects stale current schema", () => {
     const dir = makeTestDir("stale");
     dirs.push(dir);
-    createCurrentSchema(dir, { stale: true });
+    createCurrentWorkspace(dir, { stale: true });
 
     const report = assessBriefHealth(dir);
     expect(report.state).toBe("stale");
@@ -73,15 +42,7 @@ describe("assessBriefHealth", () => {
   it("detects legacy schema when old core files exist but current markers are missing", () => {
     const dir = makeTestDir("legacy");
     dirs.push(dir);
-    const briefDir = join(dir, ".brief");
-    mkdirSync(join(briefDir, "state"), { recursive: true });
-    mkdirSync(join(briefDir, "people"), { recursive: true });
-    writeFileSync(join(briefDir, FILES.priorities), "# Priorities\n");
-    writeFileSync(join(briefDir, FILES.prioritiesRaw), "# Raw\n");
-    writeFileSync(join(briefDir, FILES.decisions), "# Decisions\n");
-    writeFileSync(join(briefDir, FILES.team), "# Team\n");
-    writeFileSync(join(briefDir, FILES.overrides), "# Overrides\n");
-    writeFileSync(join(briefDir, FILES.agentLog), "# Agent Log\n");
+    createLegacyWorkspace(dir);
 
     const report = assessBriefHealth(dir);
     expect(report.state).toBe("legacy-schema");
@@ -99,9 +60,7 @@ describe("assessBriefHealth", () => {
   it("detects misconfigured brief directories", () => {
     const dir = makeTestDir("misconfigured");
     dirs.push(dir);
-    const briefDir = join(dir, ".brief");
-    mkdirSync(join(briefDir, "rules"), { recursive: true });
-    writeFileSync(join(briefDir, "rules", "BUILD.md"), "# Build\n");
+    createMisconfiguredWorkspace(dir);
 
     const report = assessBriefHealth(dir);
     expect(report.state).toBe("misconfigured");

--- a/src/__tests__/helpers/workspaces.ts
+++ b/src/__tests__/helpers/workspaces.ts
@@ -1,0 +1,68 @@
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { FILES, getStartupSchemaManifest } from "../../store/paths.js";
+
+export function makeTestDir(name: string): string {
+  const dir = `/tmp/brief-workspace-${name}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function cleanupDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+export function fillInterview(dir: string): void {
+  const file = join(dir, ".brief", FILES.humanPriorities);
+  writeFileSync(file, "# Human Priorities\n\nLast reviewed: 2026-04-08\nReviewer: test\n\n## Product Priorities\n- P0: Test\n");
+}
+
+export function createLegacyWorkspace(dir: string): void {
+  const briefDir = join(dir, ".brief");
+  mkdirSync(join(briefDir, "state"), { recursive: true });
+  mkdirSync(join(briefDir, "people"), { recursive: true });
+  writeFileSync(join(briefDir, FILES.priorities), "# Priorities\n");
+  writeFileSync(join(briefDir, FILES.prioritiesRaw), "# Raw Inputs\n");
+  writeFileSync(join(briefDir, FILES.decisions), "# Decisions\n");
+  writeFileSync(join(briefDir, FILES.team), "# Team\n");
+  writeFileSync(join(briefDir, FILES.overrides), "# Overrides\n");
+  writeFileSync(join(briefDir, FILES.agentLog), "# Agent Log\n");
+}
+
+export function createMisconfiguredWorkspace(dir: string): void {
+  const briefDir = join(dir, ".brief");
+  mkdirSync(join(briefDir, "rules"), { recursive: true });
+  writeFileSync(join(briefDir, "rules", "BUILD.md"), "# Build\n");
+}
+
+export function createCurrentWorkspace(dir: string, options: { stale?: boolean; reviewedHuman?: boolean } = {}): void {
+  const briefDir = join(dir, ".brief");
+  const manifest = getStartupSchemaManifest();
+
+  mkdirSync(briefDir, { recursive: true });
+  for (const relativeDir of manifest.requiredDirs) {
+    mkdirSync(join(briefDir, relativeDir), { recursive: true });
+  }
+
+  for (const relativeFile of manifest.requiredFiles) {
+    const fullPath = join(briefDir, relativeFile);
+    mkdirSync(join(fullPath, ".."), { recursive: true });
+    let content = "ok\n";
+    if (relativeFile === FILES.humanPriorities) {
+      content = options.reviewedHuman === false
+        ? "# Human Priorities\n\nLast reviewed: (not yet)\nReviewer: \n"
+        : "# Human Priorities\n\nLast reviewed: 2026-04-08\nReviewer: test\n";
+    }
+    writeFileSync(fullPath, content);
+  }
+
+  const prioritiesFile = join(briefDir, FILES.priorities);
+  const rawFile = join(briefDir, FILES.prioritiesRaw);
+  utimesSync(rawFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
+  utimesSync(prioritiesFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+
+  if (options.stale) {
+    utimesSync(prioritiesFile, new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
+    utimesSync(rawFile, new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+  }
+}

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -1,27 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { cleanupDir, createLegacyWorkspace, makeTestDir } from "./helpers/workspaces.js";
 
 const CLI = join(process.cwd(), "dist/index.js");
-
-function makeTestDir(name: string): string {
-  const dir = `/tmp/brief-migrate-${name}-${Date.now()}`;
-  mkdirSync(dir, { recursive: true });
-  return dir;
-}
-
-function createLegacyWorkspace(dir: string): void {
-  const briefDir = join(dir, ".brief");
-  mkdirSync(join(briefDir, "state"), { recursive: true });
-  mkdirSync(join(briefDir, "people"), { recursive: true });
-  writeFileSync(join(briefDir, "priorities.md"), "# Priorities\n");
-  writeFileSync(join(briefDir, "priorities-raw.md"), "# Raw Inputs\n");
-  writeFileSync(join(briefDir, "decisions.md"), "# Decisions\n");
-  writeFileSync(join(briefDir, "team.md"), "# Team\n");
-  writeFileSync(join(briefDir, "overrides.md"), "# Overrides\n");
-  writeFileSync(join(briefDir, "agent-log.md"), "# Agent Log\n");
-}
 
 describe("brief migrate", () => {
   it("shows a deterministic dry-run plan for legacy workspaces", () => {
@@ -34,7 +17,7 @@ describe("brief migrate", () => {
       expect(output).toContain("rules/BUILD.md");
       expect(existsSync(join(dir, ".brief", "PRIORITIES-HUMAN.md"))).toBe(false);
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      cleanupDir(dir);
     }
   });
 
@@ -50,7 +33,7 @@ describe("brief migrate", () => {
       const health = execSync(`node ${CLI} check --health`, { cwd: dir, encoding: "utf-8" });
       expect(health).toContain("health: healthy-current-schema");
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      cleanupDir(dir);
     }
   });
 
@@ -62,7 +45,7 @@ describe("brief migrate", () => {
       const output = execSync(`node ${CLI} migrate`, { cwd: dir, encoding: "utf-8" });
       expect(output).toContain("migration: nothing to do (healthy-current-schema)");
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      cleanupDir(dir);
     }
   });
 });

--- a/src/__tests__/workspace-matrix.test.ts
+++ b/src/__tests__/workspace-matrix.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { utimesSync } from "node:fs";
+import { join } from "node:path";
+import {
+  cleanupDir,
+  createCurrentWorkspace,
+  createLegacyWorkspace,
+  createMisconfiguredWorkspace,
+  fillInterview,
+  makeTestDir,
+} from "./helpers/workspaces.js";
+
+const CLI = join(process.cwd(), "dist/index.js");
+
+function runExpectingExit(command: string, cwd: string): { status: number; output: string } {
+  try {
+    const output = execSync(command, { cwd, encoding: "utf-8" });
+    return { status: 0, output };
+  } catch (error: any) {
+    return {
+      status: error.status ?? 1,
+      output: `${error.stdout || ""}${error.stderr || ""}`,
+    };
+  }
+}
+
+describe("workspace-shape CLI matrix", () => {
+  it("covers all health states through the CLI", () => {
+    const missingDir = makeTestDir("missing");
+    const legacyDir = makeTestDir("legacy");
+    const misconfiguredDir = makeTestDir("misconfigured");
+    const currentDir = makeTestDir("current");
+    const staleDir = makeTestDir("stale");
+
+    try {
+      createLegacyWorkspace(legacyDir);
+      createMisconfiguredWorkspace(misconfiguredDir);
+      createCurrentWorkspace(currentDir);
+      createCurrentWorkspace(staleDir, { stale: true });
+
+      const missing = runExpectingExit(`node ${CLI} check --health`, missingDir);
+      const legacy = runExpectingExit(`node ${CLI} check --health`, legacyDir);
+      const misconfigured = runExpectingExit(`node ${CLI} check --health`, misconfiguredDir);
+      const current = runExpectingExit(`node ${CLI} check --health`, currentDir);
+      const stale = runExpectingExit(`node ${CLI} check --health`, staleDir);
+
+      expect(missing.status).toBe(3);
+      expect(missing.output).toContain("health: missing");
+
+      expect(legacy.status).toBe(6);
+      expect(legacy.output).toContain("health: legacy-schema");
+
+      expect(misconfigured.status).toBe(4);
+      expect(misconfigured.output).toContain("health: misconfigured");
+
+      expect(current.status).toBe(0);
+      expect(current.output).toContain("health: healthy-current-schema");
+
+      expect(stale.status).toBe(5);
+      expect(stale.output).toContain("health: stale");
+    } finally {
+      cleanupDir(missingDir);
+      cleanupDir(legacyDir);
+      cleanupDir(misconfiguredDir);
+      cleanupDir(currentDir);
+      cleanupDir(staleDir);
+    }
+  });
+
+  it("covers health-aware fetch/check behavior across healthy, legacy, and stale workspaces", () => {
+    const healthyDir = makeTestDir("healthy-flow");
+    const legacyDir = makeTestDir("legacy-flow");
+    const staleDir = makeTestDir("stale-flow");
+
+    try {
+      execSync(`node ${CLI} init --template startup`, { cwd: healthyDir, encoding: "utf-8" });
+      fillInterview(healthyDir);
+      createLegacyWorkspace(legacyDir);
+      execSync(`node ${CLI} init --template startup`, { cwd: staleDir, encoding: "utf-8" });
+      fillInterview(staleDir);
+
+      const healthyFetch = runExpectingExit(`node ${CLI} fetch`, healthyDir);
+      const legacyFetch = runExpectingExit(`node ${CLI} fetch`, legacyDir);
+
+      expect(healthyFetch.status).toBe(0);
+      expect(healthyFetch.output).toContain("brief check --enrichment");
+
+      expect(legacyFetch.status).toBe(0);
+      expect(legacyFetch.output).toContain("health: legacy-schema");
+      expect(legacyFetch.output).toContain("legacy context mode");
+
+      const staleOutput = runExpectingExit(`node ${CLI} check --enrichment`, staleDir);
+      expect(staleOutput.status).toBe(0);
+
+      // force stale after init/fillInterview
+      const staleBrief = join(staleDir, ".brief");
+      utimesSync(join(staleBrief, "priorities.md"), new Date("2026-04-08T00:00:00Z"), new Date("2026-04-08T00:00:00Z"));
+      utimesSync(join(staleBrief, "priorities-raw.md"), new Date("2026-04-08T01:00:00Z"), new Date("2026-04-08T01:00:00Z"));
+      const staleCheck = runExpectingExit(`node ${CLI} check --enrichment`, staleDir);
+      expect(staleCheck.status).toBe(5);
+      expect(staleCheck.output).toContain("rules/BUILD.md + .brief/raw/");
+    } finally {
+      cleanupDir(healthyDir);
+      cleanupDir(legacyDir);
+      cleanupDir(staleDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable workspace fixture builders for current, legacy, misconfigured, and stale Brief workspaces
- convert health and migrate tests to reuse those fixtures instead of hand-rolled temp-dir setups
- add a CLI-level workspace matrix test that covers health, fetch, enrichment, and migration behavior across real workspace shapes

## Testing
- npm test

## Notes
This PR is stacked on #62 because the fixture matrix should cover the real `brief migrate` flow.

Closes #59
